### PR TITLE
🐛 Command used incorrect name to refer to a specific service

### DIFF
--- a/06-ingress-nginx.md
+++ b/06-ingress-nginx.md
@@ -52,7 +52,7 @@ Enabling gave us:
 
 Nginx can be accessed this way : 
 ```
-curl $(minikube service nginx-ingress --url)
+curl $(minikube service default-http-backend --url)
 ```
 
 Which will return 404 default backend. 


### PR DESCRIPTION
The name of the service is specified in [./ingress-nginx/nginx-backend/nginx-service.yml](ingress-nginx/nginx-backend/nginx-service.yml) as `default-http-backend`. As such, running `minikube service nginx-ingress --url` will time out, as Minikube cannot find the service.