### PR TITLE
ci: excludes linting Docker Compose YAML files

### DIFF
--- a/.test/lint_kubeval.sh
+++ b/.test/lint_kubeval.sh
@@ -2,7 +2,7 @@
 
 # Select all yaml files, except the Helmsman related ones. These are
 # detected by exluding files with filenames starting with "helmfile." or "values-".
-KUBERNETES_RESOURCE_FILES=$(find * -type f \( -iname '*.yml' -or -iname '*.yaml' \) -and ! \( -iname "helmfile.yaml" -or -iname "values-*.yaml" \))
+KUBERNETES_RESOURCE_FILES=$(find * -type f \( -iname '*.yml' -or -iname '*.yaml' \) -and ! \( -iname "helmfile.yaml" -or -iname "values-*.yaml" -or -iname "*docker-compose*" \))
 
 # Run all files through kubeval
 docker run --rm -v `pwd`:/fixtures -w /fixtures garethr/kubeval $KUBERNETES_RESOURCE_FILES


### PR DESCRIPTION
Filters out all YAML files of which the name contains "docker-compose". So, also "Prod.docker-compose.yaml" would be ignored.