### PR TITLE
docs(traefik): fixes link to traefik K8s user-guide

### DIFF
--- a/ingress-traefik/README.md
+++ b/ingress-traefik/README.md
@@ -1,2 +1,1 @@
-Follow: [https://github.com/containous/traefik/blob/master/docs/user-guide/kubernetes.md](https://github.com/containous/traefik/blob/master/docs/user-guide/kubernetes.md)
-
+Follow: [https://github.com/traefik/traefik/blob/v1.7/docs/user-guide/kubernetes.md](https://github.com/traefik/traefik/blob/v1.7/docs/user-guide/kubernetes.md)


### PR DESCRIPTION
Traefik's master branch is now at v2, where they removed the original user-guide this link referred to.

Not sure if this file is still necessary. But broken links are for sure worse than redundant links 😄 .