### PR TITLE
ci(lint): enables running linting checks on PRs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,6 @@
 name: Lint
 
-on: push
+on: [push, pull_request]
 
 jobs:
   outdated-kubernetes:


### PR DESCRIPTION
Previously, only internal push events triggered the pipelines to run. Making the results not available to PRs coming from outside the repo.