### PR TITLE
ci(lint): fixes k8s yaml extraction logic when running on linux

### DIFF
--- a/.test/extract_all_k8s_from_md.sh
+++ b/.test/extract_all_k8s_from_md.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-find . -iname "*.md" | xargs -I {} -n2 sh -c "cat {} | sh .test/parse_k8s_from_md.sh > {}.yaml"
+find . -iname "*.md" -exec sh -c "cat {} | sh .test/parse_k8s_from_md.sh > {}.yaml" \;


### PR DESCRIPTION
A difference between how `xargs` works on Mac vs Ubuntu caused the K8s snippets detected from inline Markdown not be picked up by the linter when running on Ubuntu based CI drivers. 

In the output, this caused warning to be printed in the runner, but the command did not error.
![image](https://user-images.githubusercontent.com/15435678/113682498-e8037400-96cb-11eb-85fd-df7a12616097.png)


This change replaces the use of `xargs` by instead directly using the `-exec` argument from `find`, which is tested to work similarly on both OSes.