### PR TITLE
ci(lint): migrates pluto linting tool to use docker image

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,7 +6,8 @@ jobs:
   outdated-kubernetes:
     name: Outdated K8s Resources
 
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
+
     strategy:
       matrix:
         kubernetes-version: [ '1.16.0' ]
@@ -14,16 +15,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install Pluto
-      run: brew install FairwindsOps/tap/pluto
-
     - name: Extract K8s YAML from Markdown files
       run: sh .test/extract_all_k8s_from_md.sh
 
     - name: Detect Outdated Kubernetes Resources
       run: |
-        pluto detect-files \
-        --directory . \
+        docker run -v $(pwd):/files/ quay.io/fairwinds/pluto:v4.0.7 \
+        detect-files \
+        --directory /files/ \
         --target-versions k8s=v${{ matrix.kubernetes-version }} \
         --ignore-deprecations `# Do not error when merely deprecated resources are found` \
         --output custom \


### PR DESCRIPTION
Previously, Pluto was retrieved using Homebrew, however this made the CI dependent on running on a MacOS based runner.

This change migrates the linter to use the official Docker images, which allows us to use Ubuntu based runners.

One advantage is that this should make it easier to also run the tests locally, specifically now also tools like 'act' can be used to run the pipeline locally.

Was tested on a branch based on #61, which fixes an issue specific to running the tests on Ubuntu, as such it would be better to  that this PR is merged only after #61 is merged.