### PR TITLE
ci(lint): adds K8s 1.21.0 as a linting target

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        kubernetes-version: [ '1.16.0' ]
+        kubernetes-version: [ '1.16.0', '1.21.0' ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Latest version of K8s retrieved from https://kubernetes.io/docs/setup/release/version-skew-policy/.

Linter still passes, however we have various deprecated resources, which should probably be fixed as they are removed in the next minor release (v1.22.0).

---

Detected outdated versions - note: some where already detected as deprecated by the linter:
```
NAME                         KIND                 VERSION                             REPLACEMENT                    DEPRECATED   DEPRECATED IN   REMOVED   REMOVED IN   FILEPATH                                                        
nginx                        Ingress              extensions/v1beta1                  networking.k8s.io/v1           true         v1.14.0         false     v1.22.0      /opt/app//files/06-ingress-gke.md.yaml                          
my-ingress                   Ingress              extensions/v1beta1                  networking.k8s.io/v1           true         v1.14.0         false     v1.22.0      /opt/app//files/06-ingress-gke.md.yaml                          
traefik-ingress-controller   ClusterRole          rbac.authorization.k8s.io/v1beta1   rbac.authorization.k8s.io/v1   true         v1.17.0         false     v1.22.0      /opt/app//files/06-ingress-traefik.md.yaml                      
traefik-ingress-controller   ClusterRoleBinding   rbac.authorization.k8s.io/v1beta1   rbac.authorization.k8s.io/v1   true         v1.17.0         false     v1.22.0      /opt/app//files/06-ingress-traefik.md.yaml                      
traefik-web-ui               Ingress              extensions/v1beta1                  networking.k8s.io/v1           true         v1.14.0         false     v1.22.0      /opt/app//files/06-ingress-traefik.md.yaml                      
example-nginx-ingress        Ingress              extensions/v1beta1                  networking.k8s.io/v1           true         v1.14.0         false     v1.22.0      /opt/app//files/06-ingress-traefik.md.yaml                      
nginx                        Ingress              extensions/v1beta1                  networking.k8s.io/v1           true         v1.14.0         false     v1.22.0      /opt/app//files/ingress-gke/ingress.yml                         
my-first-ingress             Ingress              extensions/v1beta1                  networking.k8s.io/v1           true         v1.14.0         false     v1.22.0      /opt/app//files/ingress-nginx/ingress.yml                       
example-nginx-ingress        Ingress              extensions/v1beta1                  networking.k8s.io/v1           true         v1.14.0         false     v1.22.0      /opt/app//files/ingress-traefik/example-ingress.yaml            
my-ingress                   Ingress              extensions/v1beta1                  networking.k8s.io/v1           true         v1.14.0         false     v1.22.0      /opt/app//files/ingress-traefik/my-ingress.yml                  
traefik-ingress-controller   ClusterRole          rbac.authorization.k8s.io/v1beta1   rbac.authorization.k8s.io/v1   true         v1.17.0         false     v1.22.0      /opt/app//files/ingress-traefik/traefik-rbac.yaml               
traefik-ingress-controller   ClusterRoleBinding   rbac.authorization.k8s.io/v1beta1   rbac.authorization.k8s.io/v1   true         v1.17.0         false     v1.22.0      /opt/app//files/ingress-traefik/traefik-rbac.yaml               
traefik-web-ui               Ingress              extensions/v1beta1                  networking.k8s.io/v1           true         v1.14.0         false     v1.22.0      /opt/app//files/ingress-traefik/traefik-webui-ingress.yaml      
traefik-ingress-controller   ClusterRole          rbac.authorization.k8s.io/v1beta1   rbac.authorization.k8s.io/v1   true         v1.17.0         false     v1.22.0      /opt/app//files/support-files/traefik-rbac-serviceaccount.yaml  
traefik-ingress-controller   ClusterRoleBinding   rbac.authorization.k8s.io/v1beta1   rbac.authorization.k8s.io/v1   true         v1.17.0         false     v1.22.0      /opt/app//files/support-files/traefik-rbac-serviceaccount.yaml  
traefik-web-ui               Ingress              extensions/v1beta1                  networking.k8s.io/v1           true         v1.14.0         false     v1.22.0      /opt/app//files/support-files/traefik-service.yaml  
```