### PR TITLE
ci(lint): bumps version of Pluto to v4.1.2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Detect Outdated Kubernetes Resources
       run: |
-        docker run -v $(pwd):/files/ quay.io/fairwinds/pluto:v4.0.7 \
+        docker run -v $(pwd):/files/ quay.io/fairwinds/pluto:v4.1.2 \
         detect-files \
         --directory /files/ \
         --target-versions k8s=v${{ matrix.kubernetes-version }} \


### PR DESCRIPTION
Bumps the version of the tool we're using to detect outdated Kubernetes resources to v4.1.2.