### PR TITLE
Change network-multitool container source from praqma to wbitt

### DIFF
--- a/01-pods-deployments.md
+++ b/01-pods-deployments.md
@@ -20,12 +20,12 @@ We start by creating our first deployment. Normally people will run a pod with a
 Here is the command to do it:
 
 ```shell
-$ kubectl create deployment multitool --image=praqma/network-multitool
+$ kubectl create deployment multitool --image=wbitt/network-multitool
 deployment.apps/multitool created
 ```
 
 So what happened? The `create`-command is great for imperative testing, and getting something up and running fast.
-  It creates a _[deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)_ named `multitool`, which creates a _[replicaset](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/)_, which starts a _[pod](https://kubernetes.io/docs/concepts/workloads/pods/)_ using the docker image `praqma/network-multitool`. You don't need to concern yourself with all these details at this stage, this is just extra (however notable) information.
+  It creates a _[deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)_ named `multitool`, which creates a _[replicaset](https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/)_, which starts a _[pod](https://kubernetes.io/docs/concepts/workloads/pods/)_ using the docker image `wbitt/network-multitool`. You don't need to concern yourself with all these details at this stage, this is just extra (however notable) information.
 
 Just so you know what we're talking about,
   you can check the objects you've created with `get <object>`,

--- a/02-service-discovery-and-loadbalancing.md
+++ b/02-service-discovery-and-loadbalancing.md
@@ -331,18 +331,18 @@ Query the service, so we know it works as expected:
 
 ```shell
 $ curl -s 35.205.60.41
-Praqma Network MultiTool (with NGINX) - customnginx-7cf9899b84-rjgrb - 10.8.2.47/24
+WBITT Network MultiTool (with NGINX) - customnginx-7cf9899b84-rjgrb - 10.8.2.47/24
 ```
 
 Next, setup a small bash loop on your local computer to curl this IP address, and get it's IP address.
 
 ```shell
 $ while true; do  curl --connect-timeout 1 -m 1 -s <loadbalancerIP> ; sleep 0.5; done
-Praqma Network MultiTool (with NGINX) - customnginx-7fcfd947cf-zbvtd - 100.96.2.36 <BR></p>
-Praqma Network MultiTool (with NGINX) - customnginx-7fcfd947cf-zbvtd - 100.96.1.150 <BR></p>
-Praqma Network MultiTool (with NGINX) - customnginx-7fcfd947cf-zbvtd - 100.96.2.37 <BR></p>
-Praqma Network MultiTool (with NGINX) - customnginx-7fcfd947cf-zbvtd - 100.96.2.37 <BR></p>
-Praqma Network MultiTool (with NGINX) - customnginx-7fcfd947cf-zbvtd - 100.96.2.36 <BR></p>
+WBITT Network MultiTool (with NGINX) - customnginx-7fcfd947cf-zbvtd - 100.96.2.36 <BR></p>
+WBITT Network MultiTool (with NGINX) - customnginx-7fcfd947cf-zbvtd - 100.96.1.150 <BR></p>
+WBITT Network MultiTool (with NGINX) - customnginx-7fcfd947cf-zbvtd - 100.96.2.37 <BR></p>
+WBITT Network MultiTool (with NGINX) - customnginx-7fcfd947cf-zbvtd - 100.96.2.37 <BR></p>
+WBITT Network MultiTool (with NGINX) - customnginx-7fcfd947cf-zbvtd - 100.96.2.36 <BR></p>
 ^C
 ```
 
@@ -358,14 +358,14 @@ pod "customnginx-3557040084-c6skw" deleted
 Immediately check the other terminal for any failed curl commands or timeouts.
 
 ```shell
-Praqma Network MultiTool (with NGINX) - customnginx-59db6cff7b-4w4gf - 10.244.0.19
-Praqma Network MultiTool (with NGINX) - customnginx-59db6cff7b-h2dbg - 10.244.0.21
-Praqma Network MultiTool (with NGINX) - customnginx-59db6cff7b-5xbjc - 10.244.0.22
-Praqma Network MultiTool (with NGINX) - customnginx-59db6cff7b-h2dbg - 10.244.0.21
-Praqma Network MultiTool (with NGINX) - customnginx-59db6cff7b-4wn9c - 10.244.0.20
-Praqma Network MultiTool (with NGINX) - customnginx-59db6cff7b-5xbjc - 10.244.0.22
-Praqma Network MultiTool (with NGINX) - customnginx-59db6cff7b-h2dbg - 10.244.0.21
-Praqma Network MultiTool (with NGINX) - customnginx-59db6cff7b-5xbjc - 10.244.0.22
+WBITT Network MultiTool (with NGINX) - customnginx-59db6cff7b-4w4gf - 10.244.0.19
+WBITT Network MultiTool (with NGINX) - customnginx-59db6cff7b-h2dbg - 10.244.0.21
+WBITT Network MultiTool (with NGINX) - customnginx-59db6cff7b-5xbjc - 10.244.0.22
+WBITT Network MultiTool (with NGINX) - customnginx-59db6cff7b-h2dbg - 10.244.0.21
+WBITT Network MultiTool (with NGINX) - customnginx-59db6cff7b-4wn9c - 10.244.0.20
+WBITT Network MultiTool (with NGINX) - customnginx-59db6cff7b-5xbjc - 10.244.0.22
+WBITT Network MultiTool (with NGINX) - customnginx-59db6cff7b-h2dbg - 10.244.0.21
+WBITT Network MultiTool (with NGINX) - customnginx-59db6cff7b-5xbjc - 10.244.0.22
 ```
 
 We notice that no curl command failed, and actually we have started seeing new IPs. Why is that? It is because, as soon as the pods are deleted, the deployment sees that it's desired state is four pods, and there is only one running, so it immediately starts three more to reach that desired state. And, while the pods are in process of starting, one surviving pod takes the traffic.

--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -21,7 +21,7 @@ kubectl create namespace my-namespace                    # Create namespace
                                                          # Set default namespace
 kubectl config set-context $(kubectl config current-context) --namespace=<my-namespace>
 
-kubectl run multitool --image=praqma/network-multitool --restart Never   # Create plain pod
+kubectl run multitool --image=wbitt/network-multitool --restart Never   # Create plain pod
 kubectl create deployment nginx --image=nginx:1.7.9      # Create deployment
 
 kubectl set image deployment/nginx nginx=nginx:1.9.1     # Update image in deployment pod template


### PR DESCRIPTION
This PR changes the source of the network-multitool to the community maintained version `wbitt/network-multitool`