### PR TITLE
Switch from Praqma multitool to WBITT multitool

### DIFF
--- a/07-healthchecks.md
+++ b/07-healthchecks.md
@@ -71,3 +71,9 @@ You have now tried out both to pause traffic to a
 given pod when its readinessprobe is failing, and
 trigger a pod restart when the livelinessprobe is
 failing.
+
+## Clean up
+
+```shell
+$ kubectl delete -f health-checks
+```

--- a/health-checks/Dockerfile
+++ b/health-checks/Dockerfile
@@ -1,3 +1,0 @@
-FROM praqma/network-multitool:extra
-RUN touch /tmp/alive
-RUN touch /tmp/ready

--- a/health-checks/probes.yaml
+++ b/health-checks/probes.yaml
@@ -14,7 +14,8 @@ spec:
     spec:
       containers:
       - name: probe
-        image: praqma/kubernetes-probe
+        image: wbitt/network-multitool:alpine-extra
+        command: ['sh', '-c', 'touch /tmp/alive && touch /tmp/ready && /docker-entrypoint.sh /usr/sbin/nginx -g "daemon off;"']
         resources:
           limits:
             memory: "128Mi"


### PR DESCRIPTION
This PR changes the container image for the health-check exercise from the (to be discontinued) praqma multitool to the wbitt multitool.