### PR TITLE
Moved to using kubeconform and added exclusions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,5 +40,4 @@ jobs:
       run: sh .test/extract_all_k8s_from_md.sh
 
     - name: Lint Kubernetes Resources
-      run: sh .test/lint_kubeval.sh
-
+      run: sh .test/lint_kube.sh

--- a/.test/lint_kube.sh
+++ b/.test/lint_kube.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Select all yaml files, except the Helmsman related ones. These are
+# detected by exluding files with filenames starting with "helmfile." or "values-".
+KUBERNETES_RESOURCE_FILES=$(find * -type f \( -iname '*.yml' -or -iname '*.yaml' \) -and ! \( -iname "helmfile.yaml" -or -iname "values-*.yaml" -or -iname "*docker-compose*" \))
+
+excludes=(
+  deployments-loadbalancing/start/frontend-deployment.yaml
+  deployments-loadbalancing/start/backend-deployment.yaml
+  manifests/start/frontend-pod.yaml
+  services/start/backend-svc.yaml
+  services/start/frontend-svc.yaml
+)
+for exclude in ${excludes[@]}
+do
+   KUBERNETES_RESOURCE_FILES=("${KUBERNETES_RESOURCE_FILES[@]/$exclude}")
+done
+
+# Run all files through kubeconform
+docker run --rm -v ${PWD}:/fixtures -w /fixtures ghcr.io/yannh/kubeconform -summary $KUBERNETES_RESOURCE_FILES

--- a/.test/lint_kubeval.sh
+++ b/.test/lint_kubeval.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# Select all yaml files, except the Helmsman related ones. These are
-# detected by exluding files with filenames starting with "helmfile." or "values-".
-KUBERNETES_RESOURCE_FILES=$(find * -type f \( -iname '*.yml' -or -iname '*.yaml' \) -and ! \( -iname "helmfile.yaml" -or -iname "values-*.yaml" -or -iname "*docker-compose*" \))
-
-# Run all files through kubeval
-docker run --rm -v `pwd`:/fixtures -w /fixtures garethr/kubeval $KUBERNETES_RESOURCE_FILES
-


### PR DESCRIPTION
I was going to submit another PR, but I saw the pipelines where failing. The linting is failing on the blank/template files used for the katas.

I went to look for a way to exclude these files and saw that kubeval is no longer being maintained:

`NOTE: This project is https://github.com/instrumenta/kubeval/issues/268#issuecomment-902128481, a good replacement is [kubeconform](https://github.com/yannh/kubeconform)`

For excluding files, I know you all have it in the `find` command, but with that turning into a longer command, I came up with this code. Not sure how you all feel about it, happy for any feedback.

Thanks for the katas - it has definitely helped me.