### PR TITLE
Fixed #110

### DIFF
--- a/deployments-ingress/done/frontend-ingress.yaml
+++ b/deployments-ingress/done/frontend-ingress.yaml
@@ -4,10 +4,10 @@ metadata:
   annotations:
     # These annotations are required to use ALB Ingress Controller
     alb.ingress.kubernetes.io/scheme: internet-facing
-    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
   name: frontend-ingress
 spec:
+  ingressClassName: "alb"
   rules:
     # you need to change the host to match your own
     - host: quotes-sal.prosa.eficode.academy

--- a/deployments-ingress/start/frontend-ingress.yaml
+++ b/deployments-ingress/start/frontend-ingress.yaml
@@ -4,10 +4,10 @@ metadata:
   annotations:
     # These annotations are required to use ALB Ingress Controller
     alb.ingress.kubernetes.io/scheme: internet-facing
-    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
   name: frontend-ingress
 spec:
+  ingressClassName: "alb"
   rules:
     # you need to change the host to match your own
     - host: quotes-<yourname>.<prefix>.eficode.academy


### PR DESCRIPTION
Warning should now disappear.

If further info is needed, provided background below.
More info on Ingress Controllers found here:
https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/

and the actual controller is AWS ALB Ingress Controller here:
https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/