### PR TITLE
Use gp3 for speed/reliability

### DIFF
--- a/persistent-storage.md
+++ b/persistent-storage.md
@@ -74,8 +74,9 @@ kubectl get StorageClasses
 Expected output:
 
 ```shell
-NAME            PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
-gp2 (default)   kubernetes.io/aws-ebs   Delete          WaitForFirstConsumer   false                  54m
+NAME   PROVISIONER             RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
+gp2    kubernetes.io/aws-ebs   Delete          WaitForFirstConsumer   false                  3h43m
+gp3    ebs.csi.aws.com         Delete          WaitForFirstConsumer   false                  3h29m
 ```
 
 We see that we indeed have a `StorageClass` available and ready for use!
@@ -127,8 +128,8 @@ Next we fill in the values:
 - The `apiVersion` should be `v1`
 - The `kind` is `PersistentVolumeClaim`
 - The `metadata.name` should be `postgres-pvc`
-- From the previous section we know that we have one available `StorageClass`, so the value of
-  `spec.storageClassName` is the name of that, in this case `"gp2"` (with quotes)
+- From the previous section we know that we have one two `StorageClass` available, so we should choose one of them. "gp3" is faster and cheaper than "gp2" in AWS, so let's go with that by setting 
+  `spec.storageClassName` to `"gp3"` (with quotes)
 - The `spec.accessModes` list should contain one item with the value `ReadWriteOnce`
 - the `spec.resources.requests.storage` is the size of the volume in Gibibytes (Gi), set it to `5Gi`
 
@@ -141,7 +142,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: postgres-pvc
 spec:
-  storageClassName: "gp2"
+  storageClassName: "gp3"
   accessModes:
     - ReadWriteOnce
   resources:
@@ -173,7 +174,7 @@ Expected output:
 
 ```text
 NAME           STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   AGE
-postgres-pvc   Pending                                      gp2            3m19s
+postgres-pvc   Pending                                      gp3            3m19s
 ```
 
 Check if a `PersistentVolume` was created using `kubectl get`:
@@ -332,7 +333,7 @@ Expected output:
 
 ```text
 NAME                                 STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
-persistentvolumeclaim/postgres-pvc   Bound    pvc-60e5235b-e2bb-4d71-9136-3901ca4dece9   5Gi        RWO            gp2            <unset>                 3m55s
+persistentvolumeclaim/postgres-pvc   Bound    pvc-60e5235b-e2bb-4d71-9136-3901ca4dece9   5Gi        RWO            gp3            <unset>                 3m55s
 
 NAME                                                        CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                STORAGECLASS   VOLUMEATTRIBUTESCLASS   REASON   AGE
 persistentvolume/pvc-00e46d16-c3a8-4b4c-8ccd-aaef24970f01   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-7    gp3            <unset>                          8d
@@ -356,7 +357,7 @@ persistentvolume/pvc-24ea8c05-8bdb-485b-8541-3eb67d2de012   25Gi       RWO      
 persistentvolume/pvc-2a99943d-b33a-4e70-bedf-c76a4470dde1   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-84   gp3            <unset>                          8d
 persistentvolume/pvc-2cb0beda-b70a-4801-b1b2-2cb05d851837   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-62   gp3            <unset>                          8d
 persistentvolume/pvc-2ee41664-c2f7-46ac-a509-23dd905fb548   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-24   gp3            <unset>                          8d
-persistentvolume/pvc-3068b592-6f5c-40af-8f66-2f954e591bcf   5Gi        RWO            Delete           Bound    student-76/postgres-pvc                              gp2            <unset>                          5m53s
+persistentvolume/pvc-3068b592-6f5c-40af-8f66-2f954e591bcf   5Gi        RWO            Delete           Bound    student-76/postgres-pvc                              gp3            <unset>                          5m53s
 persistentvolume/pvc-33c97802-67b5-483b-a8e8-d80884ec1196   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-29   gp3            <unset>                          8d
 persistentvolume/pvc-3535a091-be7f-449b-8989-d148b70852d7   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-67   gp3            <unset>                          8d
 persistentvolume/pvc-3792c72a-695a-4d68-9027-180963099f30   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-46   gp3            <unset>                          8d
@@ -371,11 +372,11 @@ persistentvolume/pvc-4ef28400-5fe4-414f-bde4-4ad7bf85f67f   25Gi       RWO      
 persistentvolume/pvc-503543a6-2605-4774-852a-b5a113cc53f5   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-15   gp3            <unset>                          8d
 persistentvolume/pvc-50391d8c-aecb-4846-bfa3-d7fef0d3b2fd   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-52   gp3            <unset>                          8d
 persistentvolume/pvc-574f3e6a-d7fd-4aad-a883-060b3a96d020   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-50   gp3            <unset>                          8d
-persistentvolume/pvc-5a245381-a2bc-4eb5-ba57-2da4c3b369c8   5Gi        RWO            Delete           Bound    default/postgres-pvc                                 gp2            <unset>                          8d
+persistentvolume/pvc-5a245381-a2bc-4eb5-ba57-2da4c3b369c8   5Gi        RWO            Delete           Bound    default/postgres-pvc                                 gp3            <unset>                          8d
 persistentvolume/pvc-5b78be48-effc-43a7-b97d-315647117934   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-25   gp3            <unset>                          8d
 persistentvolume/pvc-5cfac69b-2987-41e9-a31d-64977c114be6   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-23   gp3            <unset>                          8d
 persistentvolume/pvc-60a6bab6-d141-46c5-a5d9-ce4180cb0a67   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-57   gp3            <unset>                          8d
-persistentvolume/pvc-60e5235b-e2bb-4d71-9136-3901ca4dece9   5Gi        RWO            Delete           Bound    student-19/postgres-pvc                              gp2            <unset>                          14s
+persistentvolume/pvc-60e5235b-e2bb-4d71-9136-3901ca4dece9   5Gi        RWO            Delete           Bound    student-19/postgres-pvc                              gp3            <unset>                          14s
 persistentvolume/pvc-626158a5-6acc-41f3-a2f4-7d613dd426dd   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-79   gp3            <unset>                          8d
 persistentvolume/pvc-6499594c-af86-4b63-bc01-5f5c886db94b   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-78   gp3            <unset>                          8d
 persistentvolume/pvc-66056829-2e5d-49eb-be99-119ee33aa3cd   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-27   gp3            <unset>                          8d
@@ -404,7 +405,7 @@ persistentvolume/pvc-9454a68d-153a-4d80-a170-0bb45d61dce6   25Gi       RWO      
 persistentvolume/pvc-94ede42f-75cc-45d6-9f84-63b5f9c4978e   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-54   gp3            <unset>                          8d
 persistentvolume/pvc-9b24acf2-80c1-4b05-add5-753d268513ab   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-1    gp3            <unset>                          8d
 persistentvolume/pvc-9cf3f0c5-935b-4a9a-bd60-7eacdfeb186a   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-16   gp3            <unset>                          8d
-persistentvolume/pvc-a5f6d728-026d-48f9-b7ef-c7e49eea3199   5Gi        RWO            Delete           Bound    student-44/postgres-pvc                              gp2            <unset>                          9s
+persistentvolume/pvc-a5f6d728-026d-48f9-b7ef-c7e49eea3199   5Gi        RWO            Delete           Bound    student-44/postgres-pvc                              gp3            <unset>                          9s
 persistentvolume/pvc-aa995fa4-7c0b-4bd4-bf67-7745f739b6b4   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-47   gp3            <unset>                          8d
 persistentvolume/pvc-abf09c27-03e0-4b6a-8454-48e435f71f6e   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-19   gp3            <unset>                          8d
 persistentvolume/pvc-af5efa42-db08-416d-af61-e92354570d52   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-43   gp3            <unset>                          8d
@@ -423,9 +424,9 @@ persistentvolume/pvc-e30cbac1-00e3-4d2a-a4c8-d7bf67069592   25Gi       RWO      
 persistentvolume/pvc-e37b322a-1a60-48ce-ab7c-f110989801e7   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-30   gp3            <unset>                          8d
 persistentvolume/pvc-e3d0e01b-09c4-4ebf-b150-e2ef72ec7d46   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-49   gp3            <unset>                          8d
 persistentvolume/pvc-e85c0f94-e1d3-4234-9eb8-19541fa9d38f   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-33   gp3            <unset>                          8d
-persistentvolume/pvc-f2ad2087-120d-417b-aa53-26b0fe41d416   5Gi        RWO            Delete           Bound    student-0/postgres-pvc                               gp2            <unset>                          6h17m
+persistentvolume/pvc-f2ad2087-120d-417b-aa53-26b0fe41d416   5Gi        RWO            Delete           Bound    student-0/postgres-pvc                               gp3            <unset>                          6h17m
 persistentvolume/pvc-fa0dca95-bf4a-437b-9112-ad6b5ec7dacd   25Gi       RWO            Delete           Bound    code-server-workstations/coder-home-workstation-80   gp3            <unset>                          8d
-persistentvolume/pvc-fc17f2e1-c7bc-4a43-8e3d-956dbedb0e97   8Gi        RWO            Delete           Bound    monitoring/prometheus-server                         gp2            <unset>                          8d
+persistentvolume/pvc-fc17f2e1-c7bc-4a43-8e3d-956dbedb0e97   8Gi        RWO            Delete           Bound    monitoring/prometheus-server                         gp3            <unset>                          8d
 ```
 
 ### Delete pod with volume attached and observe that state is persisted when a new pod is created

--- a/persistent-storage.md
+++ b/persistent-storage.md
@@ -128,9 +128,9 @@ Next we fill in the values:
 - The `apiVersion` should be `v1`
 - The `kind` is `PersistentVolumeClaim`
 - The `metadata.name` should be `postgres-pvc`
-- From the previous section we know that we have one two `StorageClass` available, so we should choose one of them.
-  "gp3" is faster and cheaper than "gp2" in AWS, so let's go with that by setting 
-  `spec.storageClassName` to `"gp3"` (with quotes)
+- From the previous section we know that we have one two `StorageClass` available, so we should
+  choose one of them. "gp3" is faster and cheaper than "gp2" in AWS, so let's go with that by
+  setting `spec.storageClassName` to `"gp3"` (with quotes)
 - The `spec.accessModes` list should contain one item with the value `ReadWriteOnce`
 - the `spec.resources.requests.storage` is the size of the volume in Gibibytes (Gi), set it to `5Gi`
 

--- a/persistent-storage.md
+++ b/persistent-storage.md
@@ -128,7 +128,8 @@ Next we fill in the values:
 - The `apiVersion` should be `v1`
 - The `kind` is `PersistentVolumeClaim`
 - The `metadata.name` should be `postgres-pvc`
-- From the previous section we know that we have one two `StorageClass` available, so we should choose one of them. "gp3" is faster and cheaper than "gp2" in AWS, so let's go with that by setting 
+- From the previous section we know that we have one two `StorageClass` available, so we should choose one of them.
+  "gp3" is faster and cheaper than "gp2" in AWS, so let's go with that by setting 
   `spec.storageClassName` to `"gp3"` (with quotes)
 - The `spec.accessModes` list should contain one item with the value `ReadWriteOnce`
 - the `spec.resources.requests.storage` is the size of the volume in Gibibytes (Gi), set it to `5Gi`


### PR DESCRIPTION
Perhaps overcomplicating it a bit, but gp3 is a much better disk type to use due to the fact it has higher performance for roughly the same cost.

Plus it doesn't have a burst credit system :partying_face:

gp2 was the only option at the time of creation, so the reference to "only one" will need cleaning up regardless.