### PR TITLE
Markdown linting and Langauge fixes

### DIFF
--- a/accessing-your-application.md
+++ b/accessing-your-application.md
@@ -32,14 +32,14 @@ You can then access the pod on `localhost:8080`.
 <details>
 <summary>:bulb: How does this port-forward work?</summary>
 
-Port forwarding is a network address translation that redirects Internet packets from one IP address to another.
-with a specified port number to another `IP:PORT` set.
+Port forwarding is a network address translation that redirects Internet packets from one IP address
+to another with a specified port number to another `IP:PORT` set.
 
 In Kubernetes `port-forward` creates a tunnel between your local machine and the Kubernetes cluster on
 the specified `IP:PORT` pairs to establish a connection to the cluster.
 `kubectl port-forward` allows you to forward not only pods but also services, deployments, and others.
 
-More information can be found from [port-forward-access-application-cluste](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
+More information can be found from [Use Port Forwarding to Access Applications in a Cluster](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
 
 </details>
 

--- a/accessing-your-application.md
+++ b/accessing-your-application.md
@@ -10,13 +10,13 @@
 
 Deploying a pod is not enough to make it accessible from outside the cluster.
 
-In this exercise you will learn how to make temporary connections to a pod inside the cluster via
+In this exercise, you will learn how to make temporary connections to a pod inside the cluster via
 `kubectl port-forward`.
 
 ## Port-forward
 
 The `kubectl port-forward` command allows you to forward one or more local ports to a pod. This can
-be used to access a pod that is running in the cluster, using for example a web browser or a
+be used to access a pod that is running in the cluster, using a web browser or a
 command line tool like `curl`.
 
 The command takes two arguments: the pod name and the port to forward. The port is specified as
@@ -32,12 +32,12 @@ You can then access the pod on `localhost:8080`.
 <details>
 <summary>:bulb: How does this port-forward work?</summary>
 
-Port forwarding is a network address translation that redirects internet packets form one IP address
-with specified port number to another `IP:PORT` set.
+Port forwarding is a network address translation that redirects Internet packets from one IP address to another.
+with a specified port number to another `IP:PORT` set.
 
-In Kubernetes `port-forward` creates a tunnel between your local machine and Kubernetes cluster on
-the specified `IP:PORT` pairs in order to establish connection to the cluster.
-`kubectl port-forward` allows you to forward not only pods but also services, deployments and other.
+In Kubernetes `port-forward` creates a tunnel between your local machine and the Kubernetes cluster on
+the specified `IP:PORT` pairs to establish a connection to the cluster.
+`kubectl port-forward` allows you to forward not only pods but also services, deployments, and others.
 
 More information can be found from [here](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
 
@@ -58,7 +58,7 @@ More information can be found from [here](https://kubernetes.io/docs/tasks/acces
 
 > :bulb: If you get stuck somewhere along the way, you can check the solution in the done folder.
 
-### Step by step instructions
+### Step-by-step instructions
 
 <details>
 <summary>
@@ -78,7 +78,7 @@ The pod is defined in the `frontend-pod.yaml` file.
 
 </details>
 
-- Check that the pod is running with `kubectl get pods` command.
+- Check that the pod is running with the `kubectl get pods` command.
 
 You should see something like this:
 
@@ -89,30 +89,30 @@ frontend   1/1     Running   0          2m
 
 - Expose the frontend with port-forward
 
-Port forward can be achieved with:
+Port forwarding can be achieved with:
 
 `kubectl port-forward --address 0.0.0.0 frontend 8080:5000`
 
 > :bulb: We add the `--address 0.0.0.0` option to the port-forward command to make it accept
 > commands coming from remote machines, like your laptop! `0.0.0.0` Means any address, so you
-> probably don't want to do this on your own machine in, unless you want to expose something
+> probably don't want to do this on your machine unless you want to expose something
 > to the internet.
 
 It can now be accessed on `http://workstation-<number>.<prefix>.eficode.academy:8080`
 (from the internet). Notice the plain, unencrypted `http` connection. It is not `https`, and your
-browser may complain about it. TLS is an advanced topic and out of scope for now.
+browser may complain about it. TLS is an advanced topic and is currently out of scope.
 
-> :bulb: VSCode will ask you if you what to see the open port. Unfortunately vscode proxy does not
-> proxy requests correctly back to the pod, so use the URL of the instance instead.
+:bulb: VSCode will prompt you to view the open port. Unfortunately, vscode proxy does not
+> proxy requests correctly back to the pod, so use the URL of the workstation instance instead.
 
 - Look at it in the browser.
 
 Now we will deploy both the frontend and backend pods.
 
 - Stop the port-forward process by pressing `Ctrl-c` in the terminal.
-- Delete the frontend pod with `kubectl delete pod frontend` command.
-- Deploy the backend pod with `kubectl apply -f backend-pod.yaml` command.
-- Check that the pod is running, and note down the IP with `kubectl get pods -o wide` command.
+- Delete the frontend pod with the `kubectl delete pod frontend` command.
+- Deploy the backend pod with the `kubectl apply -f backend-pod.yaml` command.
+- Check that the pod is running, and note down the IP with the `kubectl get pods -o wide` command.
 
 You should see something like this:
 
@@ -123,7 +123,7 @@ NAME      READY   STATUS    RESTARTS   AGE   IP            NODE                 
 backend   1/1     Running   0          11s   10.0.40.196   ip-10-0-35-102.eu-west-1.compute.internal   <none>           <none>
 ```
 
-In this case the IP is `10.0.40.196`, but it will be different in your case.
+In this case, the IP is `10.0.40.196`, but it will be different in your case.
 
 #### Add environment variables to the frontend pod
 
@@ -178,9 +178,9 @@ spec:
 
 </details>
 
-- Deploy the frontend pod with `kubectl apply -f frontend-pod.yaml` command.
+- Deploy the frontend pod with the `kubectl apply -f frontend-pod.yaml` command.
 
-- Check that the pod is running with `kubectl get pods` command.
+- Check that the pod is running with the `kubectl get pods` command.
 
 - Forward a local port to the pod using `kubectl port-forward`.
 
@@ -190,9 +190,9 @@ You should see something like this:
 
 ![alt](img/app-front-back.png)
 
-(if you don't you might need to refresh the page)
+(If you don't, you might need to refresh the page.)
 
-- Exec into the frontend pod with `kubectl exec -it frontend -- /bin/sh` command.
+- Exec into the frontend pod with the command `kubectl exec -it frontend -- /bin/sh`.
 
 - Execute a curl command to the backend `curl http://<BACKEND_IP>:5000`.
 
@@ -205,10 +205,10 @@ Extra exercise
 
 While still having the port-forward running
 
-- Access the frontend in the browser and check that it still works and that frontend has access to
+- Access the frontend in the browser and check that it still works and that the frontend has access to
   the backend.
-- Try to delete the backend pod with `kubectl delete pod backend` command.
-- Try to recreate the backend pod with `kubectl apply -f backend-pod.yaml` command.
+- Try to delete the backend pod with the command `kubectl delete pod backend`.
+- Try to recreate the backend pod with the command `kubectl apply -f backend-pod.yaml`.
 - Access the frontend in the browser.
 - Does it still have access to the backend?
 
@@ -218,10 +218,10 @@ If not, why not?
 <summary>Solution</summary>
 
 The frontend pod is not configured to automatically re-resolve the backend IP address.
-So when we deleted the pod, and recreated it, the IP address changed, but the frontend pod still
+So when we deleted the pod and recreated it, the IP address changed, but the frontend pod still
 has the old IP address in its environment variables.
 
-Thankfully Kubernetes has a networking abstraction called `services` which solves this exact (and
+Thankfully, Kubernetes has a networking abstraction called `services` which solves this exact (and
 more!) problem, which we will learn about in the next exercise.
 
 </details>
@@ -230,9 +230,9 @@ more!) problem, which we will learn about in the next exercise.
 
 ### Clean up
 
-- Stop the port-forward with `Ctrl+C` command.
-- Delete the pod with `kubectl delete pod frontend` command.
-- Delete the pod with `kubectl delete pod backend` command.
+- Stop the port-forward with the `Ctrl+C` command.
+- Delete the pod with the `kubectl delete pod frontend` command.
+- Delete the pod with the `kubectl delete pod backend` command.
 
 Congratulations! You have now learned how to make temporary connections to a pod inside the cluster
 via `kubectl port-forward`, and how to use environment variables to configure the pod.

--- a/accessing-your-application.md
+++ b/accessing-your-application.md
@@ -39,7 +39,7 @@ In Kubernetes `port-forward` creates a tunnel between your local machine and the
 the specified `IP:PORT` pairs to establish a connection to the cluster.
 `kubectl port-forward` allows you to forward not only pods but also services, deployments, and others.
 
-More information can be found from [here](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
+More information can be found from [port-forward-access-application-cluste](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
 
 </details>
 

--- a/accessing-your-application.md
+++ b/accessing-your-application.md
@@ -35,11 +35,13 @@ You can then access the pod on `localhost:8080`.
 Port forwarding is a network address translation that redirects Internet packets from one IP address
 to another with a specified port number to another `IP:PORT` set.
 
-In Kubernetes `port-forward` creates a tunnel between your local machine and the Kubernetes cluster on
-the specified `IP:PORT` pairs to establish a connection to the cluster.
-`kubectl port-forward` allows you to forward not only pods but also services, deployments, and others.
+The `port-forward` command in Kubernetes forwards incoming traffic to the machine, the command is
+executed on, to the specified `IP:PORT` pairs inside the Kubernetes cluster. This effectively
+lets traffic from outside the cluster reach applications running inside the cluster.
+`kubectl port-forward` allows you to forward traffic to pods, services, deployments, and others.
 
-More information can be found from [Use Port Forwarding to Access Applications in a Cluster](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
+More information can be found in the Kubernetes docs at
+[Use Port Forwarding to Access Applications in a Cluster](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
 
 </details>
 
@@ -78,7 +80,7 @@ The pod is defined in the `frontend-pod.yaml` file.
 
 </details>
 
-- Check that the pod is running with the `kubectl get pods` command.
+- Use the `kubectl get pods` command to verify that the pod is running.
 
 You should see something like this:
 
@@ -87,7 +89,7 @@ NAME       READY   STATUS    RESTARTS   AGE
 frontend   1/1     Running   0          2m
 ```
 
-- Expose the frontend with port-forward
+- Expose the frontend with `port-forward`
 
 Port forwarding can be achieved with:
 

--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -7,7 +7,7 @@ kubectl config set-context $(kubectl config current-context) --namespace=my-name
                                                          # Change default namespace
 
 kubectl help run                                         # See help about run (or other commands)
-kubectl explain pod.spec                                 # Documenation on any resource attribute
+kubectl explain pod.spec                                 # Documentation on any resource attribute
 
 kubectl get nodes                                        # See nodes in cluster
 kubectl get pods -o wide                                 # See pods in current namespace
@@ -15,7 +15,7 @@ kubectl get pod <name> -o yaml                           # See info about pod <n
 kubectl describe pod <name>                              # Show information about pod <name>
 kubectl describe service <name>                          # Show information about service <name>
 
-kubectl api-resources                                    # See resources types and abbreviations
+kubectl api-resources                                    # See resource types and abbreviations
 
 kubectl create namespace my-namespace                    # Create namespace
                                                          # Set default namespace

--- a/configmaps-secrets.md
+++ b/configmaps-secrets.md
@@ -8,13 +8,13 @@
 ## Introduction
 
 Configmaps and secrets are a way to store information that is used by several deployments and pods
-in your cluster. This makes it easy to update the configuration in one place, when you want to
+in your cluster. This makes it easy to update the configuration in one place when you want to
 change it.
 
 Both configmaps and secrets are generic `key-value` pairs, but secrets are `base64 encoded` and
 configmaps are not.
 
-> :bulb: Secrets are not encrypted, they are encoded. This means that if someone gets access to the
+> :bulb: Secrets are not encrypted; they are encoded. This means that if someone gets access to the
 > cluster, they will be able to read the values.
 
 ## ConfigMaps
@@ -23,10 +23,10 @@ You use a ConfigMap to keep your application code separate from your configurati
 
 It is an important part of creating a [Twelve-Factor Application](https://12factor.net/).
 
-This lets you change easily configuration depending on the environment (development, production,
+This lets you change configuration easily depending on the environment (development, production,
 testing, etc.) and to dynamically change configuration at runtime.
 
-A ConfigMap manifest looks like this in yaml:
+A ConfigMap manifest looks like this in YAML:
 
 ```yaml
 apiVersion: v1
@@ -101,7 +101,7 @@ data:
 
 `secrets` are used for storing configuration that is considered sensitive, and well ... _secret_.
 
-When you create a `secret` Kubernetes will go out of it's way to not print the actual values of
+When you create a `secret`, Kubernetes will go out of its way to not print the actual values of
 secret object, to things like logs or command output.
 
 You should use `secrets` to store things like passwords for databases, API keys, certificates, etc.
@@ -113,19 +113,19 @@ source these values from environment variables.
 actual values are `base64` encoded. `base64` encoded means that the values are obscured, but can be
 trivially decoded. When values from a `secret` are used, Kubernetes handles the decoding for you.
 
-> :bulb: As `secrets` don't actually make their data secret for anyone with access to the cluster,
+> :bulb: As `secrets` don't make their data secret for anyone with access to the cluster,
 > you should think of `secrets` as metadata for humans, to know that the data contained within is
 > considered secret.
 
 ## Using ConfigMaps and Secrets in a deployment
 
-To use a configmap or secret in a deployment, you can either mount it in as a volume, or use it
+To use a configmap or secret in a deployment, you can either mount it as a volume or use it
 directly as an environment variable.
 
 ### Injecting a ConfigMap as environment variables
 
 This will inject all key-value pairs from a configmap as environment variables in a container.
-The keys will be the name of variables, and the values will be values of the variables.
+The keys will be the names of variables, and the values will be the values of the variables.
 
 ```yaml
 apiVersion: apps/v1
@@ -151,10 +151,10 @@ spec:
 
 - Add the database part of the application
 - Change the database user into a configmap and implement that in the backend
-- Change the database password into a secret, and implement that in the backend.
+- Change the database password to a secret, and implement that in the backend.
 - Change database deployment to use the configmap and secret.
 
-### Step by step instructions
+### Step-by-step instructions
 
 <details>
 <summary>
@@ -168,7 +168,7 @@ Step by step:
 We have already created the database part of the application, with a deployment and a service.
 
 - Look at the database deployment file `postgres-deployment.yaml`.
-  Notice the database username and password are injected as hardcoded environment variables.
+  Notice that the database username and password are injected as hardcoded environment variables.
 
 > :bulb: This is not a good practice, as we do not want to store these values in version control.
 > We will fix this in the next steps.
@@ -194,10 +194,10 @@ postgres-6fbd757dd7-ttpqj  1/1     Running   0          4s
 #### Refactor the database user into a configmap and implement that in the backend
 
 We want to change the database user into a configmap, so that we can change it in one place, and
-use it on all deployments that needs it.
+use it on all deployments that need it.
 
 - Create a configmap with the name `postgres-config` and filename `postgres-config.yaml` and the
-  information about database configuration as follows:
+  information about the database configuration as follows:
 
 ```yaml
 data:
@@ -238,7 +238,7 @@ data:
 
 </details>
 
-- apply the configmap with `kubectl apply -f postgres-config.yaml`
+- Apply the configmap with `kubectl apply -f postgres-config.yaml`
 - In the `backend-deployment.yaml`, change the environment variables to use the configmap instead
   of the hardcoded values.
 
@@ -266,14 +266,14 @@ data:
         name: postgres-config
   ```
 
-- re-apply the backend deployment with `kubectl apply -f backend-deployment.yaml`
-- check that the website is still running.
+- Re-apply the backend deployment with `kubectl apply -f backend-deployment.yaml`
+- Check that the website is still running.
 
 #### Change the database password into a secret, and implement that in the backend
 
-We want to change the database password into a secret, so that we can change it in one place, and
-use it on all deployments that needs it.
-In order for this, we need to change the backend deployment to use the secret instead of the
+We want to change the database password to a secret, so that we can change it in one place, and
+use it on all deployments that need it.
+For this, we need to change the backend deployment to use the secret instead of the
 configmap for the password itself.
 
 - create a secret with the name `postgres-secret` and the following data:
@@ -340,12 +340,12 @@ envFrom:
 
 We are going to implement the configmap and secret in the database deployment as well.
 
-The standard Postgres docker image can be configured by setting specific environment variables,
+The standard Postgres Docker image can be configured by setting specific environment variables,
 ([you can see the documentation here](https://hub.docker.com/_/postgres)).
-By populating these specific values we can configure the credentials for root user and the name of
-the database to be created.
+By populating these specific values, we can configure the credentials for the root user and the name
+of the database to be created.
 
-This means that we need to change the way we are injecting the environment variables, in order to
+This means that we need to change the way we are injecting the environment variables, to
 make sure the environment variables have the correct names.
 
 - Open the `postgres-deployment.yaml` file, and change the way the environment variables are
@@ -371,8 +371,8 @@ env:
         key: DB_PASSWORD
 ```
 
-- re-apply the database deployment with `kubectl apply -f postgres-deployment.yaml`
-- check that the website is still running, and that the new database can be reached from the backend.
+- Re-apply the database deployment with `kubectl apply -f postgres-deployment.yaml`
+- Check that the website is still running, and that the new database can be reached from the backend.
 
 Congratulations! You have now created a configmap and a secret, and used them in your application.
 

--- a/deployments-ingress.md
+++ b/deployments-ingress.md
@@ -5,7 +5,7 @@
 - Learn how to expose a deployment using Ingress
 - Learn how to use `deployments`
 - Learn how to scale deployments
-- Learn how to use `services` to do loadbalance between the pods of a scaled deployment
+- Learn how to use `services` to do load balancing between the pods of a scaled deployment
 
 ## Introduction
 
@@ -14,7 +14,7 @@ scale it, and how to expose it using an `Ingress` resource with URL routing.
 
 ## Deployments
 
-Deployments are a higher level abstraction than pods, and controls the lifecycle
+Deployments are a higher-level abstraction than pods, and control the lifecycle
 and configuration of a "deployment" of an application. They are used to manage a
 set of pods, and to ensure that a specified number of pods are always running
 with the desired configuration. `deployments` are a Kubernetes `kind` and
@@ -71,13 +71,13 @@ spec:
 
 ### High Availability
 
-In order to make our application stable, we want **high availability**. High availability means that
+To make our application stable, we want **high availability**. High availability means that
 we replicate our applications, such that we have **redundant copies**, which means that _when_ an
 application fails, our users are not impacted, as they will simply use one of the other copies,
 while the failed instance recovers.
 
-In Kubernetes this is done in practice by `scaling` a deployment, e.g. by adding or removing
-`replicas`. `replicas` are **identical** copies of the **the same pod**.
+In Kubernetes, this is done in practice by `scaling` a deployment, e.g., by adding or removing
+`replicas`. `replicas` are **identical** copies of the **same pod**.
 
 To scale a deployment, we change the number of `replicas` in the manifest file, and then apply the
 changes using `kubectl apply -f <manifest-file>`.
@@ -135,11 +135,11 @@ ingress-controller called ALB, and the ALB will route traffic to the service.
 - Scale the deployment by adding a replicas key
 - Turn frontend pod manifests into a deployment manifest
 - Apply the frontend deployment manifest
-- Test service promise of high availability
+- Test the service promise of high availability
 
-> :bulb: If you get stuck somewhere along the way, you can check the solution inthe done directory.
+> :bulb: If you get stuck somewhere along the way, you can check the solution in the **done** directory.
 
-### Step by step instructions
+### Step-by-step instructions
 
 <details>
 <summary>
@@ -148,9 +148,9 @@ Step by step:
 
 - Go into the `deployments-ingress/start` directory.
 
-In the directory we have the pod manifests for the backend and frontend that have created in the
+In the directory, we have the pod manifests for the backend and frontend that were created in the
 previous exercises. We also have two services, one for the backend (type ClusterIP) and one for the
-frontend (type NodePort) as well as an ingress manifest for the frontend.
+frontend (type NodePort), as well as an ingress manifest for the frontend.
 
 #### Add Ingress to frontend service
 
@@ -192,9 +192,8 @@ It will take a while for the ingress to work, so we will continue with the backe
 
 #### Deploy the quotes application
 
-To show how Deployments take the place of Pod manifests we will
-first deploy the quotes application, and then slowly replace the
-Pods with Deployments.
+To show how Deployments take the place of Pod manifests, we will first deploy the quotes application,
+and then slowly replace the Pods with Deployments.
 
 - Deploy the following using the `kubectl apply -f` command
   - `frontend-pod.yaml`
@@ -210,7 +209,7 @@ Pods with Deployments.
 How do I connect to a pod through a NodePort service?
 </summary>
 
-> :bulb: In previous exercises you learned how connect to a pod exposed through a NodePort service,
+> :bulb: In previous exercises, you learned how to connect to a pod exposed through a NodePort service,
 > you need to find the nodePort using `kubectl get service` and the IP address of one of the nodes
 > using `kubectl get nodes -o wide`
 > Then combine the node IP address and nodePort with a colon between them, in a browser or using curl:
@@ -224,12 +223,11 @@ http://<node-ip>:<nodePort>
 #### Turn the backend pod manifests into a deployment manifest
 
 Now we'll replace the Pod manifest with a Deployment manifest. In addition to the regular
-manifest fields, we need to set couple of extra things:
+manifest fields, we need to set a couple of extra things:
 
-1. A Pod `template`. This almost a copy of most of the Pod manifest. This defines the Pods
+1. A Pod `template`. This is almost a copy of most of the Pod manifest. This defines the Pods
    that will be created by the deployment.
-2. A `selectorLabel`. This is used to determine which pods to manage will be managed by the
-   ReplicaSet.
+2. A `selectorLabel`. This is used to determine which pods will be managed by the ReplicaSet.
 3. A number of `replicas`. This specifies how many simultaneous identical copies we want of the Pod
 
 To do this, open both the `backend-deployment.yaml` and the `backend-pod.yaml` files in your editor,
@@ -243,7 +241,7 @@ Now we need to set the `selectorLabel`
 
 - Add a `selector` key under the `spec` key
 - Add a `matchLabels` key under the `selector` key
-- Look up the the `metadata.label` section in `backend-pod.yaml`
+- Look up the `metadata.label` section in `backend-pod.yaml`
   and the labels defined there under `matchLabels`
 
 <details>
@@ -353,20 +351,20 @@ Deployment. We've already deployed the Pod, so let us remove it again before app
 
 - Access the frontend again from the browser.
 
-  Now the Ingress should work and you should be able to access the frontend from the browser using
+  Now the Ingress should work, and you should be able to access the frontend from the browser using
   the hostname you specified in the ingress manifest.
 
-  The url should look something like this:
+  The URL should look something like this:
 
   ```text
   http://quotes-<yourname>.<prefix>.eficode.academy
   ```
 
-- If it still does not work, you can check it through NodePort service instead.
+- If it still does not work, you can check it through the NodePort service instead.
 
 - You should now see the backend.
 
-- If this works, please delete the `backend-pod.yaml` file, as we now have upgraded to a deployment
+- If this works, please delete the `backend-pod.yaml` file, as we have now upgraded to a deployment
   and no longer need it!
 
 #### Scale the deployment by adding a replicas key
@@ -424,12 +422,12 @@ backend-5f4b8b7b4-7x7xg   1/1       Running   0          1m
 
 #### Turn frontend pod manifests into a deployment manifest
 
-You will now do the exact same thing for the frontend, we will walk you through it again, but at a
-higher level, if get stuck you can go back and double check how you did it for the backend.
+You will now do the same thing for the frontend. We will walk you through it again, but at a
+higher level. If you get stuck, you can go back and double-check how you did it for the backend.
 
 - Open both the `frontend-deployment.yaml` and the `frontend-pod.yaml` files in your editor.
-- add the api-version and kind keys to the `frontend-deployment.yaml` file.
-- Give the deployment a name of `frontend` under `metadata.name` key.
+- Add the api-version and kind keys to the `frontend-deployment.yaml` file.
+- Give the deployment a name of `frontend` under the `metadata.name` key.
 - Add a label of `run: frontend` under `metadata.labels` key.
 - Set `spec.replicas` to `3`.
 - Copy the `metadata` and `spec` contents of the `frontend-pod.yaml` file into the
@@ -499,7 +497,7 @@ frontend-47b45fb8b-4x7xg   1/1       Running   0          1m
 - Access the frontend again from the browser.
   Note that both the frontend and backend hostname parts of the website should change periodically.
 
-- If this works, please delete the `frontend-pod.yaml` file, as we now have upgraded to a deployment
+- If this works, please delete the `frontend-pod.yaml` file, as we have now upgraded to a deployment
   and no longer need it!
 
 </details>
@@ -531,7 +529,7 @@ kubectl delete -f frontend-ingress.yaml
 
 ## Extra Exercise
 
-Test Kubernetes promise of resiliency and high availability
+Test the Kubernetes promise of resiliency and high availability
 
 <details>
 <summary>
@@ -541,7 +539,7 @@ An example of using a LoadBalancer service to route traffic to replicated pods
 We can use the `ghcr.io/eficode-academy/network-multitool` image to illustrate both high
 availability and load balancing of `services`. The `network-multitool` pod will serve a tiny
 webpage that dynamically contains the pod hostname and IP address of the pod. This enables us to see
-which of a group of network-multitool pods that served the request.
+which of a group of network-multitool pods served the request.
 
 Create the network-multitool deployment:
 
@@ -558,11 +556,11 @@ We also create a service of type `LoadBalancer`:
 kubectl expose deployment customnginx --port 80 --type LoadBalancer
 ```
 
-> :bulb: It might take a minute to provision the LoadBalancer, if you are using AWS, then
+> :bulb: It might take a minute to provision the LoadBalancer. If you are using AWS, then
 > `kubectl get services` will show you the DNS name of the provisioned LoadBalancer immediately, but
 > it will be a moment before it is ready.
 
-When the LoadBalancer is ready we setup a loop to keep sending requests to the pods:
+When the LoadBalancer is ready, we set up a loop to keep sending requests to the pods:
 
 ```shell
 while true; do  curl --connect-timeout 1 -m 1 -s <loadbalancerIP> ; sleep 0.5; done
@@ -578,8 +576,8 @@ Eficode Academy Network MultiTool (with NGINX) - customnginx-7fcfd947cf-zbvtd - 
 Eficode Academy Network MultiTool (with NGINX) - customnginx-7fcfd947cf-zbvtd - 100.96.2.36 <BR></p>
 ```
 
-We see that when we query the LoadBalancer IP, it is giving us result/content from all four pods.
-None of the curl commands time out.
+We see that when we query the LoadBalancer IP, it is giving us results/content from all four pods.
+None of the curl commands times out.
 Now, if we kill three out of four pods, the service should still respond, without timing out.
 We let the loop run in a separate terminal, and kill three pods of this deployment from another terminal.
 
@@ -613,11 +611,11 @@ Eficode Academy Network MultiTool (with NGINX) - customnginx-59db6cff7b-h2dbg - 
 Eficode Academy Network MultiTool (with NGINX) - customnginx-59db6cff7b-5xbjc - 10.244.0.22
 ```
 
-We notice that no curl commands failed, and actually we have started seeing new IPs.
+We notice that no curl commands failed, and actually, we have started seeing new IPs.
 
-Why is that? It is because, as soon as the pods are deleted, the deployment sees that it's desired
+Why is that? It is because, as soon as the pods are deleted, the deployment sees that its desired
 state is four pods, and there is only one running, so it immediately starts three more to reach the
-desired state of four pods. And, while the pods are in process of starting, one surviving pod serves
+desired state of four pods. And, while the pods are in the process of starting, one surviving pod serves
 all of the traffic, preventing our application from missing any requests.
 
 ```shell
@@ -637,8 +635,8 @@ customnginx-3557040084-fw1t3   1/1       Running       0          16m
 customnginx-3557040084-xqk1n   1/1       Running       0          15s
 ```
 
-This proves, Kubernetes enables high availability, by using multiple replicas of a pod, and
-loadbalancing between them.
+This proves, Kubernetes enables high availability by using multiple replicas of a pod, and
+load-balancing between them.
 
 Remember to clean up the deployment afterwards with:
 

--- a/desired-state.md
+++ b/desired-state.md
@@ -2,21 +2,21 @@
 
 Desired state is one of the core concepts of Kubernetes. It is the state that you want your cluster
 to be in. It is the state that you define in your Kubernetes manifests. It means that the cluster
-continously will try to fulfill your desired state, even if it will never be posible to reach it.
+continuously will try to fulfill your desired state, even if that will never be possible.
 
-In this exercise you will apply Kubernetes manifests to your cluster, and learn how Kubernetes
+In this exercise, you will apply Kubernetes manifests to your cluster and learn how Kubernetes
 fulfills your desired state.
 
 ## Controllers
 
-Kubernetes controllers are the components that fulfills your desired state. As the example we will
-use here, a deployment controller will attempt to do so that the number of pods that you have
-defined in your manifest is always running in the cluster.
+Kubernetes controllers are the components that fulfill your desired state. The example we will
+use is a deployment controller, which will attempt to ensure that the number of pods that you have
+defined in your manifest are always running in the cluster.
 
 ## Learning Goals
 
 - Applying Kubernetes manifests using `kubectl apply -f <file>`.
-- Verifying Kubernetes promise of fulfilling your desired state.
+- Verifying the Kubernetes promise of fulfilling your desired state.
 
 ## Exercise
 
@@ -25,9 +25,9 @@ defined in your manifest is always running in the cluster.
 - Inspect existing Kubernetes manifest for a `deployment` object.
 - Apply the manifest using the `kubectl apply` command.
 - Delete a pod managed by the deployment controller.
-- Observe that a new pod is created in it's place by the controller.
+- Observe that a new pod is created in its place by the controller.
 
-### Step by step instructions
+### Step-by-step instructions
 
 <details>
 <summary>
@@ -58,7 +58,7 @@ spec:
   template:
     metadata:
       labels:
-        app: nginx # pod labels that must match selector
+        app: nginx # pod labels that must match the selector
         version: latest # arbitrary label we can match on elsewhere
     spec:
       containers:
@@ -108,14 +108,14 @@ NAME                         READY     STATUS    RESTARTS   AGE
 nginx-431080787-9r0lx        1/1       Running   0          40s
 ```
 
-Kubernetes is now doing everything it can to satisfy our desired state of running our nginx webserver.
+Kubernetes is now doing everything it can to satisfy our desired state of running our nginx web server.
 
-Let's test that Kubernetes actually keeps it's promise of fulfilling the desired state.
+Let's test that Kubernetes keeps its promise of fulfilling the desired state.
 
 ## Test Kubernetes promise of desired state by deleting a pod
 
 Since we have asked Kubernetes to run our nginx pod using a `deployment`, the deployment controller
-will keep monitoring our pods and make sure that a nginx pod keeps running.
+will keep monitoring our pods and make sure that an nginx pod keeps running.
 
 Let's see this in action:
 
@@ -138,13 +138,13 @@ pod "nginx-431080787-9r0lx" deleted
 ```
 
 The desired state we have defined specifies that exactly one nginx pod should exist, since we have
-now deleted the nginx pod, we have forced our `deployment` to drift away from the desired state, as
-there are now zero nginx pods.
+now deleted the nginx pod, we have forced our `deployment` to drift away from the desired state, because
+now there are zero nginx pods.
 
-Therefore Kubernetes must make a change to the state of the cluster to once again fulfill our
-desired state, therefore Kubernetes will create a new nginx pod to replace the one we have deleted.
+Therefore, Kubernetes must make a change to the state of the cluster to once again fulfill our
+desired state and create a new nginx pod to replace the one we have deleted.
 
-## Observe that a new pod is created in it's place by the deployment controller
+## Observe that a new pod is created in its place by the deployment controller
 
 We use `kubectl get` to verify that a **new** nginx pod is created (with a different name):
 
@@ -159,7 +159,7 @@ NAME                         READY     STATUS              RESTARTS   AGE
 nginx-431080787-tx5m7        0/1       ContainerCreating   0          5s
 ```
 
-And after few more seconds:
+And after a few more seconds:
 
 ```shell
 kubectl get pods
@@ -174,7 +174,7 @@ nginx-431080787-tx5m7        1/1       Running   0          12s
 
 Congratulations! You have now created a deployment using a Kubernetes manifest.
 
-You have also seen that Kubernetes keeps it's promise of fulfilling your desired state, by creating
+You have also seen that Kubernetes keeps its promise of fulfilling your desired state by creating
 a new pod in the place of the deleted pod.
 
 </details>

--- a/exercise-template.md
+++ b/exercise-template.md
@@ -6,15 +6,15 @@
 
 ## Introduction
 
-Here you will provide the bare minimum of information people need to solve the exercise.
+Here, you will provide the bare minimum of information people need to solve the exercise.
 
 ## Subsections
 
 You can have several subsections if needed.
 
 <details>
-<summary>:bulb: If an explanaition becomes too long, the more detailed parts can be encapsulated in
-a drop down section</summary>
+<summary>:bulb: If an explanation becomes too long, the more detailed parts can be encapsulated in
+a drop-down section</summary>
 </details>
 
 ## Exercise
@@ -23,15 +23,15 @@ a drop down section</summary>
 
 - In bullets, what are you going to solve as a student
 
-### Step by step instructions
+### Step-by-step instructions
 
 <details>
 <summary>More Details</summary>
 
 > **NOTE**: Take **the same bullet names as above** and put them in to illustrate how far the
-> student have gone. Then **delete this line**.
+> student has gone. Then **delete this line**.
 
-- all actions that you believe the student should do, should be in a bullet
+- All actions that you believe the student should do should be in a bullet point
 
 > :bulb: Help can be illustrated with bulbs in order to make it easy to distinguish.
 

--- a/intro.md
+++ b/intro.md
@@ -1,7 +1,7 @@
 # Kubernetes-introduction
 
 In this course, we will learn how to deploy applications in Kubernetes.
-We will start by deploying the entire quotes application the way it will be done when we are done
+We will start by deploying the entire quotes application, the way it will be done when we are done
 with the course.
 
 ## Deploying an application
@@ -11,7 +11,7 @@ We will be deploying a small example Python Flask application that displays quot
 The application consists of three components: Frontend, backend and a database.
 
 The frontend and backend are small Python Flask webservers that listen for HTTP requests.
-For persistent storage, a postgresql database is used.
+For persistent storage, a PostgreSQL database is used.
 
 ## Learning Goals
 
@@ -24,31 +24,31 @@ For persistent storage, a postgresql database is used.
 In Kubernetes, we run containers, but we don't manage containers directly. Containers are instead
 placed inside `pods`. A `pod` _contains_ containers.
 
-Pods in turn are managed by controllers, the most common one is called a `deployment`.
+Pods, in turn, are managed by controllers, the most common one is called a `deployment`.
 
 And in order to make the application accessible from the outside, we use a `service`. Don't worry
 if you feel a bit overwhelmed, we will go through them in detail later in the course.
 
-Kubernetes resources are declared in what is called `manifests` which use a markup language called
+Kubernetes resources are declared in what is called `manifests`, which use a markup language called
 `yaml` to express the desired state of resources.
 
 ### Imperative vs Declarative
 
-You can use the Kubernetes CLI to create, delete and modify resources in two ways - imperatively
+You can use the Kubernetes CLI to create, delete, and modify resources in two ways - imperatively
 and declaratively.
 
-Imperatively means that you are actively _creating, deleting and modifying_ resources. And if for
-example you run a create command twice, you will end up with one resource and a "fail to create"
+Imperatively means that you are actively _creating, deleting, and modifying_ resources. So if you
+run a create command twice, you will end up with one resource and a "fail to create"
 error message, because it is already created.
 
 Declaratively means that you _declare what you want,_ and _not how_ Kubernetes should do it. If you
-run the same command twice, you will end up with just one resources. This is because Kubernetes
+run the same command twice, you will end up with just one resource. This is because Kubernetes
 will fulfill your desired state, and if it already exists, it will not create it again.
 
 Doing things **imperatively** is fine for _hacking_ on things, but most of the time we want to work
 with Kubernetes **declaratively**.
 
-Therefore we much prefer to do things **declaratively**.
+Therefore, we prefer to do things **declaratively**.
 Declaratively means that we _declare what we want,_ and _not how_ Kubernetes should do it.
 
 This declaration is what we call our `desired state`.
@@ -69,7 +69,7 @@ To use it, type `kubectl <subcommand> <options>` in a terminal.
 - Apply the Quotes flask application using the `kubectl apply` command.
 - Access the application from the Internet
 
-### Step by step instructions
+### Step-by-step instructions
 
 <details>
 <summary>Step by step</summary>
@@ -89,7 +89,7 @@ Try to see if you can find information about:
 - The image used for the container
 - The port the container listens on
 
-Do not worry if you don't understand everything yet, we will go through it in detail later in the course.
+Do not worry if you don't understand everything yet; we will go through it in detail later in the course.
 
 ### Apply the manifest using the `kubectl apply`
 
@@ -134,7 +134,7 @@ postgres        1/1     1            1           27s
 
 ### Access the application from the Internet
 
-We are getting a little ahead of our exercises here, but to illustrate that we actually have
+We are getting a little ahead of our exercises here, but to illustrate that we have
 a functioning application running in our cluster, let's try accessing it from a browser!
 
 First off, get the `service` called `frontend` and note down the NodePort, by finding the `PORT(S)`
@@ -154,7 +154,7 @@ NAME        TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
 frontend    NodePort   10.96.223.218   <none>        80:32458/TCP   12s
 ```
 
-In this example, Kubernetes has chosen port `32458`, you will most likely get a different number.
+In this example, Kubernetes has chosen port `32458`; you will most likely get a different number.
 
 Finally, look up the IP address of a node in the cluster with:
 
@@ -162,7 +162,7 @@ Finally, look up the IP address of a node in the cluster with:
 kubectl get nodes -o wide
 ```
 
-> :bulb: The `-o wide` flag makes the output more verbose, i.e. to include the IPs
+> :bulb: The `-o wide` flag makes the output more verbose, i.e., to include the IPs
 
 Expected output:
 
@@ -172,13 +172,13 @@ node1   Ready    . . . 10.123.0.8   35.240.20.246   . . .
 node2   Ready    . . . 10.123.0.7   35.205.245.42   . . .
 ```
 
-In the example your external IPs are either `35.240.20.246` or `35.205.245.42`.
+In the example, your external IP address is either `35.240.20.246` or `35.205.245.42`.
 
-The `frontend` `service` is of type `NodePort` and will be exposed on _all_ of the nodes. The
+The `frontend` service is of type `NodePort` and will be exposed on _all_ of the nodes. The
 service will be exposed on the port with the number you noted down above.
 
 Choose one of the `EXTERNAL-IP`'s, and point your web browser to the address:
-`<EXTERNAL-IP>:<PORT>`.
+`<EXTERNAL-IP>:<PORT>` - note the colon `:` that separates EXTERNAL-IP and PORT
 
 In this example, the address could be `35.240.20.246:32458`, or `35.205.245.42:32458`.
 
@@ -200,7 +200,7 @@ kubectl delete -f quotes-flask/
 
 If you have more time, take a look at the YAML manifests that we used to deploy the application.
 They are in the `quotes-flask` folder.
-First take a look at the deployment manifest, and see if you can find the following information:
+First, take a look at the deployment manifest, and see if you can find the following information:
 
 - The name of the deployment
 - The number of replicas

--- a/manifests.md
+++ b/manifests.md
@@ -2,7 +2,7 @@
 
 ## Learning Goals
 
-- Write your own declarative manifest to run a simple web application in a pod.
+- Write your declarative manifest to run a simple web application in a pod.
 
 ## Introduction
 
@@ -111,11 +111,11 @@ spec:
 
 ### Apply the `pod` manifest
 
-Try to apply the manifest with `kubectl apply -f frontend-pod.yaml` command.
+Try to apply the manifest with the `kubectl apply -f frontend-pod.yaml` command.
 
 ### Verify the `pod` is created correctly
 
-Check the status of the pod with `kubectl get pods` command.
+Check the status of the pod with the `kubectl get pods` command.
 
 Expected output:
 
@@ -131,6 +131,6 @@ applied it to the cluster.
 
 ### Clean up
 
-Delete the pod with `kubectl delete pod frontend` command.
+Delete the pod with the `kubectl delete pod frontend` command.
 
 Congratulations! You have now learned how to make a manifest detailing our frontend pod.

--- a/persistent-storage.md
+++ b/persistent-storage.md
@@ -277,7 +277,7 @@ Fill in the values:
 - `mountPath` is the path in the container to mount the volume to. For postgres, the database state is
   stored to the path `/var/lib/postgresql/data`
 - `subPath` should be `postgres`, and specifies a directory to be created within the volume. We need
-  this because of a quirk with combining `AWS EBS` with Postgres. (If you are curious, why:
+  this because of a quirk with combining `AWS EBS` with Postgres. (If you are curious why:
   <https://stackoverflow.com/a/51174380>)
 
 <details>

--- a/persistent-storage.md
+++ b/persistent-storage.md
@@ -1,11 +1,11 @@
 # Persistent Storage
 
-In this exercise you will learn how to persist the filesystem state of your containers using
+In this exercise, you will learn how to persist the filesystem state of your containers using
 dynamic volume provisioning.
 
 ## Learning Goals
 
-- How to attach a volume to container in a pod
+- How to attach a volume to a container in a pod
 - How to use dynamic volume provisioning to create persistent block storage to save the
   state of your applications
 - How to create PersistentVolumes and use them with PersistentVolumeClaims
@@ -14,7 +14,7 @@ dynamic volume provisioning.
 
 Kubernetes, a persistent volume claim (PVC) is a request for storage by a user. It is a way for a
 pod to request a specific amount of storage from the cluster. When a PVC is created, it is
-automatically bound to a persistant volume (PV) that satisfies the PVC's requirements.
+automatically bound to a persistent volume (PV) that satisfies the PVC's requirements.
 
 A storage class (SC) is a way to define the properties of a PV. It is a blueprint for creating PVs,
 and it specifies things like the type of storage, the amount of storage, and the access modes for
@@ -31,20 +31,20 @@ In summary:
 
 ### Overview
 
-- Observe that the state of the postgres database is not persisted between pod lifecycles
+- Observe that the state of the PostgreSQL database is not persisted between pod lifecycles
 - Inspect the Available StorageClasses (sc) of the cluster
-- Create a PersistentVolume (pv) using dynamic volume provisioning
-- Consume the PersistentVolume using a PersistentVolumeClaim (pvc) and mounting the volume to a pod
-- Delete pod with volume attached and observe that state is persisted when a new pod is created
+- Create a PersistentVolume (PV) using dynamic volume provisioning
+- Consume the PersistentVolume using a PersistentVolumeClaim (PVC) and mount the volume to a pod
+- Delete the pod with the volume attached and observe that the state is persisted when a new pod is created
 
-### Step by step instructions
+### Step-by-step instructions
 
 <details>
 <summary>
 Step by step:
 </summary>
 
-### Observe that the state of the postgres database is not persisted between pod lifecycles
+### Observe that the state of the PostgreSQL database is not persisted between pod lifecycles
 
 Deploy the manifests located in `persistent-storage/start`
 
@@ -53,14 +53,14 @@ Deploy the manifests located in `persistent-storage/start`
 
 - Open the frontend webpage in your browser.
 - Observe that the frontend reports that it is connected to the database.
-- Add some quotes. We will need them later to test persistency
-- Retrieve all of the quotes, observe that your quotes are part of the retrieved quotes.
+- Add some quotes. We will need them later to test persistence
+- Retrieve all of the quotes, and observe that your quotes are part of the retrieved quotes.
 - Now delete the postgres pod using `kubectl delete pod <pod-name>`
 - In the frontend webpage, retrieve quotes, and observe that you now only get the default 5 quotes
   from the database.
 
 What we have observed here is that the state of our database is not persisted between pod lifecycles!
-In order to fix this, we need to persist the filesystem state of our database container to a `volume`.
+To fix this, we need to persist the filesystem state of our database container to a `volume`.
 
 ### Inspect the Available StorageClasses (sc) of the cluster
 
@@ -87,8 +87,8 @@ We see that we indeed have a `StorageClass` available and ready for use!
 
 The output of the `kubectl get sc` command provides some useful information about the StorageClass:
 
-- `PROVISIONER` what is the underlying storage provider, in this case `AWS EBS` (Elastic Block Storage)
-- `RECLAIMPOLICY` what will happen with the volume when the `PersistentVolume` resource is deleted,
+- `PROVISIONER` The underlying storage provider, in this case `AWS EBS` (Elastic Block Storage)
+- `RECLAIMPOLICY` What will happen with the volume when the `PersistentVolume` resource is deleted,
   in this case `Delete` will delete the block storage.
 - `VOLUMEBINDINGMODE` specifies how to provision the actual volume, `WaitForFirstConsumer` will
   provision the actual volume object once there is a matching claim.
@@ -96,13 +96,13 @@ The output of the `kubectl get sc` command provides some useful information abou
 
 </details>
 
-### Create a PersistentVolume (pv) using dynamic volume provisioning
+### Create a PersistentVolume (PV) using dynamic volume provisioning
 
-Let's create a `PersistentVolume` (pv)!
+Let's create a `PersistentVolume` (PV)!
 
-While we could create a manifest for a `PersistentVolume` manually we will not do that in this exercise.
+While we could create a manifest for a `PersistentVolume` manually, we will not do that in this exercise.
 
-In practice we will almost always create a `PersistentVolume` by creating `PersistentVolumeClaim`,
+In practice, we will almost always create a `PersistentVolume` by creating a `PersistentVolumeClaim`,
 which uses a `StorageClass` to create the actual volume.
 
 Create a new file `persistent-storage/start/postgres-pvc.yaml`
@@ -128,7 +128,7 @@ Next we fill in the values:
 - The `apiVersion` should be `v1`
 - The `kind` is `PersistentVolumeClaim`
 - The `metadata.name` should be `postgres-pvc`
-- From the previous section we know that we have one two `StorageClass` available, so we should
+- From the previous section, we know that we have one or two `StorageClass` available, so we should
   choose one of them. "gp3" is faster and cheaper than "gp2" in AWS, so let's go with that by
   setting `spec.storageClassName` to `"gp3"` (with quotes)
 - The `spec.accessModes` list should contain one item with the value `ReadWriteOnce`
@@ -153,7 +153,7 @@ spec:
 
 </details>
 
-Apply your new `PersistenVolumeClaim` with `kubectl apply`:
+Apply your new `PersistentVolumeClaim` with `kubectl apply`:
 
 ```shell
 kubectl apply -f persistent-storage/start/postgres-pvc.yaml
@@ -190,12 +190,12 @@ Expected output
 No resources found
 ```
 
-> :bulb: `PersistentVolumes` objects are `cluster-wide`, ie. "not-namespaced", so you might see
+> :bulb: `PersistentVolumes` objects are `cluster-wide`, ie, "not-namespaced", so you might see
 > `PersistentVolumes` belonging to other users.
 
 We expect that a PersistentVolume has not been created _yet._
 
-As we can see in the `kubectl get persistentvolumeclaim` output above, our `PersistenVolumeClaim`
+As we can see in the `kubectl get persistentvolumeclaim` output above, our `PersistentVolumeClaim`
 is in the `Pending` status.
 
 This is because the `VOLUMEBINDINGMODE` of the StorageClass is set to `WaitForFirstConsumer`, as we
@@ -203,13 +203,13 @@ saw in the previous section.
 
 `WaitForFirstConsumer` will not create the actual volume object until it is used by a pod.
 
-> :bulb: The reason you might not want to not always create volumes as soon as `pvc` objects are
+> :bulb: The reason you might not want to always create volumes as soon as `pvc` objects are
 > created is to reduce costs, by not creating resources that are not used before they are attached
 > to a pod.
 
-Let's attach the PersistenVolumeClaim to our postgres pod!
+Let's attach the PersistentVolumeClaim to our postgres pod!
 
-### Consume the PersistentVolume using a PersistentVolumeClaim (pvc) and mounting the volume to a pod
+### Consume the PersistentVolume using a PersistentVolumeClaim (PVC) and mount the volume to a pod
 
 Open the postgres deployment manifest in your text editor `persistent-storage/start/postgres-deployment.yaml`.
 
@@ -230,9 +230,9 @@ Add the values to the snippet:
 - `spec.template.spec.volumes[0].name` is the name we will reference when we mount the volume to a
   container in a moment. Set it to `postgres-pvc`.
 - `spec.template.spec.volumes[0].persistentVolumeClaim.claimName` is the `name` of the
-  `PersistenVolumeClaim` we have created above, set it to the name you used, e.g. `postgres-pvc`.
+  `PersistentVolumeClaim` we have created above, set it to the name you used, e.g., `postgres-pvc`.
 
-> :bulb: In this case the volume name and reference to the `pvc` name are the same, this is
+> :bulb: In this case, the volume name and reference to the `pvc` name are the same; this is
 > coincidental, and they can be different.
 
 <details>
@@ -259,9 +259,9 @@ spec:
 
 </details>
 
-Next we mount the volume we have defined to the postgres container:
+Next, we mount the volume we have defined to the postgres container:
 
-In the deployment manifest file, add the following section to the postgres container spec, e.g. `spec.template.spec.containers[0].volumeMounts`
+In the deployment manifest file, add the following section to the postgres container spec, e.g., `spec.template.spec.containers[0].volumeMounts`
 
 ```yaml
 volumeMounts:
@@ -273,11 +273,11 @@ volumeMounts:
 Fill in the values:
 
 - `name` should be the name we specified above when we declared the available volumes.
-  In this case this should be `postgres-pvc`
-- `mountPath` is the path in container to mount the volume to. For postgres, the database state is
+  In this case, this should be `postgres-pvc`
+- `mountPath` is the path in the container to mount the volume to. For postgres, the database state is
   stored to the path `/var/lib/postgresql/data`
-- `subPath` should be `postgres`, and specifies a directory to be created within the volume, we need
-  this because of a quirk with combining `AWS EBS` with Postgres. (If you are curios why:
+- `subPath` should be `postgres`, and specifies a directory to be created within the volume. We need
+  this because of a quirk with combining `AWS EBS` with Postgres. (If you are curious, why:
   <https://stackoverflow.com/a/51174380>)
 
 <details>
@@ -297,7 +297,7 @@ spec:
       volumes:
         - name: postgres-pvc # name we can reference below in container
           persistentVolumeClaim:
-            claimName: postgres-pvc # name of the actual pvc
+            claimName: postgres-pvc # name of the actual PVC
       containers:
         - image: docker.io/library/postgres:14.3
           name: postgres
@@ -312,7 +312,7 @@ spec:
 
 </details>
 
-Apply the changes to the postgres deployment using `kubectl apply`:
+Apply the changes to the PostgreSQL deployment using `kubectl apply`:
 
 ```shell
 kubectl apply -f persistent-storage/start/postgres-deployment
@@ -432,13 +432,13 @@ persistentvolume/pvc-fc17f2e1-c7bc-4a43-8e3d-956dbedb0e97   8Gi        RWO      
 
 ### Delete pod with volume attached and observe that state is persisted when a new pod is created
 
-Now that the state of our postgres database is persisted to the volume, let's verify:
+Now that the state of our PostgreSQL database is persisted to the volume, let's verify:
 
 - Open the frontend webpage and add some quotes
 - Retrieve quotes from the database, and observe that your quotes are among them
 - Delete the database pod with `kubectl delete pod <postgres-pod-name>`
 - Wait for the postgres pod to be recreated (you can watch for pod changes with `kubectl get pods --watch`)
-- In the frontend webpage, retrieve quotes and obeserve that your quotes are among them
+- In the frontend webpage, retrieve quotes and observe that your quotes are among them
 
 </details>
 

--- a/rolling-updates.md
+++ b/rolling-updates.md
@@ -3,12 +3,12 @@
 ## Learning Goals
 
 - Learn about how to update deployments
-- Learn about how to test resiliency of your deployment
+- Learn about how to test the resiliency of your deployment
 - Learn about how to control the rollout process with `maxSurge` and `maxUnavailable`
 
 ## Introduction
 
-In this exercise you'll learn about how to update a deployment.
+In this exercise, you'll learn about how to update a deployment.
 
 ### maxSurge and maxUnavailable parameters
 
@@ -31,11 +31,11 @@ version with the new one.
 
 ### Overview
 
-- Roll out new version of either the frontend or backend and see the changes
+- Roll out a new version of either the frontend or backend and see the changes
 - Roll out a new version that does not exist
 - Change the `maxSurge` and `maxUnavailable` parameters and see how it affects the rollout
 
-### Step by step instructions
+### Step-by-step instructions
 
 <details>
 <summary>
@@ -57,17 +57,17 @@ Now go ahead and `apply` the deployments and the services:
 <details>
 <summary>:bulb: How is it that you do that?</summary>
 
-- Find the service with `kubectl get services` command.
+- Find the service with the `kubectl get services` command.
 
-- Note down the port number for the frontend service. In this case it is `31941`
+- Note down the port number for the frontend service. In this case, it is `31941`
 
 - Get the nodes EXTERNAL-IP address. Run `kubectl get nodes -o wide`.
 
-Copy the external IP address of any one of the nodes, for example, `34.244.123.152` and paste it in
+Copy the external IP address of any one of the nodes, for example, `34.244.123.152`, and paste it in
 your browser.
 
-Copy the port from your frontend service that looks something like `31941` and paste it next to
-your IP in the browser, for example, `34.244.123.152:31941` and hit it.
+Copy the port from your frontend service that looks something like `31941` and paste it next to your
+IP in the browser separated by colon `:`, for example, `34.244.123.152:31941` and hit it.
 
 </details>
 
@@ -106,7 +106,7 @@ It might be that you only see the last line, as the rollout is very fast.
 
 - Check the version of the backend image in the browser
 
-- Try rolling out other image version while looking at the frontend. You can do it by repeating the
+- Try rolling out another image version while looking at the frontend. You can do it by repeating the
   commands from above. Suggested image versions are `1.0.0` and `3.0.0`.
 
 - Try also rolling out a version that does not exist:
@@ -118,7 +118,7 @@ spec:
       name: backend
 ```
 
-What happened - do the frontend still work? And are you able to see the backend version in the browser?
+What happened - does the frontend still work? And are you able to see the backend version in the browser?
 
 - Investigate the running pods with: `kubectl get pods`
 
@@ -155,7 +155,7 @@ spec:
 
 ## Clean up
 
-Delete deployments and services as follow:
+Delete deployments and services as follows:
 
 - `kubectl delete -f .`
 

--- a/rolling-updates.md
+++ b/rolling-updates.md
@@ -118,7 +118,7 @@ spec:
       name: backend
 ```
 
-What happened - does the frontend still work? And are you able to see the backend version in the browser?
+What happened? Does the frontend still work? Are you able to see the backend version in the browser?
 
 - Investigate the running pods with: `kubectl get pods`
 

--- a/services.md
+++ b/services.md
@@ -8,15 +8,15 @@
 
 ## Introduction
 
-In this exercise you'll learn about how pods can be exposed using services and test connectivity
+In this exercise, you'll learn about how pods can be exposed using services and test connectivity
 between them.
 
 ## Service Discovery & Services
 
-One of the features of Kubernetes is that we do not have to care on which machine our pods are
-running. This does create an interesting problem for us - if we don't know where (the IP address)
+One of the features of Kubernetes is that we do not have to care which machine our pods are
+running on. This does create an interesting problem for us - if we don't know where (the IP address)
 the pod is, how can we route traffic to it? This is solved by what is called **service discovery**,
-as the words imply, Kubernetes will look for your pods, and dynamically route traffic to them.
+as the words imply, Kubernetes will look for your pods and dynamically route traffic to them.
 
 This is achieved using the Kubernetes kind `service`, which is a network abstraction for service
 discovery (and more!).
@@ -29,12 +29,12 @@ the `service` to match the same labels. This is handled by the Kubernetes API, w
 only need to know the labels of the pods we want to send traffic to, and Kubernetes will take of
 the rest!
 
-The `service` then routes traffic the pods that it selects, you can think of `service` as a kind of
+The `service` then routes traffic to the pods that it selects. You can think of `service` as a kind of
 proxy - you route traffic to the service, and the service routes the traffic to your pods.
 
-While the `service` gets a static IP address we actually prefer not use it, because Kubernetes
-actually runs its own DNS server in the cluster network, and every time we create a `service` a DNS
-record is created that points to the `service` IP address.
+While the `service` gets a static IP address, we prefer not to use it, because Kubernetes
+runs its own DNS server in the cluster network, and every time we create a `service`, a DNS record is
+created that points to the `service` IP address.
 The DNS record is always the `name` of the service, and can be referenced either from the same
 namespace by using the name or from a different namespace by using the long form:
 `<name>.<namespace>.svc.cluster.local`.
@@ -90,9 +90,9 @@ a pod. Instead, we can create a service that will expose the pod(s) to the outsi
 service IP address will not change, even if the pod(s) it is exposing are destroyed and recreated.
 It will only change if the service is deleted and recreated.
 
-The service also load balances traffic between the pods it is exposing if there are more than one pod.
+The service also load balances traffic between the pods it exposes, if there is more than one pod.
 
-The service finds the pods it is exposing by using labels. The service will expose all pods that
+The service identifies the pods it exposes by using labels. The service will expose all pods that
 have the labels specified in the `selector` part of the service.
 
 ### `service` Manifest
@@ -154,19 +154,19 @@ internet, but we can still access it from within the cluster using its `CLUSTER-
 
 - The IPs assigned to services as Cluster-IP are from a different Kubernetes network called
   _Service Network_, which is a completely different network altogether. i.e. it is not connected
-  (nor related) to pod-network or the infrastructure network. Technically it is actually not a real
-  network per-se; it is a labeling system, which is used by Kube-proxy on each node to setup
-  correct iptables rules. (This is an advanced topic, and not our focus right now).
+  (nor related) to the pod-network or the infrastructure network. Technically, it is not a real
+  network per se; it is a labeling system, which is used by Kube-proxy on each node to set up
+  correct iptables rules. (This is an advanced topic, and not our focus right now.)
 
 - No matter what type of service you choose while _exposing_ your pod, Cluster-IP is always
   assigned to that particular service.
 
-- Every service has end-points, which point to the actual pod serving as a backend of a particular
+- Every service has endpoints, which point to the actual pod serving as the backend of a particular
   service.
 
-- As soon as a service is created, and is assigned a Cluster-IP, an entry is made in Kubernetes'
+- As soon as a service is created and is assigned a Cluster-IP, an entry is made in Kubernetes'
   internal DNS against that service, with this service name and the Cluster-IP. e.g.
-  `backend.default.svc.cluster.local` would point to Cluster-IP `172.20.114.230` .
+  `backend.default.svc.cluster.local` would point to Cluster-IP `172.20.114.230`.
 
 </details>
 
@@ -176,7 +176,7 @@ Services of type `NodePort` have all of the functionality of `ClusterIP` service
 functionality: It will also open up a port on each node in the cluster, which will route traffic to
 the service.
 
-For example a `NodePort` service might open port `32593` on all nodes, and route traffic from this
+For example, a `NodePort` service might open port `32593` on all nodes, and route traffic from this
 port to the service.
 
 So now, if we know the IP of our nodes (and they are externally accessible), we can access this
@@ -186,27 +186,27 @@ service from the internet.
 
 There are other types of services, like `LoadBalancer`, but we won't cover them in this exercise.
 
-If you want to know more about Services, you can read more about them [publishing-services-service-types](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
+If you want to know more about Services, you can read more about them [Service types](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
 
 > :bulb: Hint: You can use the `kubectl explain` command to get more information about the fields
-> in the yaml file. For example, `kubectl explain service.spec` will give you more information
-> about the spec field in the service yaml file.
+> in the YAML file. For example, `kubectl explain service.spec` will give you more information
+> about the spec field in the service YAML file.
 
 ## Exercise
 
-In this exercise you will start both the frontend and backend quotes-flask pods.
+In this exercise, you will start both the frontend and backend quotes-flask pods.
 
 ### Overview
 
 - Apply both frontend and backend pods
-- Create backend service with type ClusterIP
+- Create a backend service with type ClusterIP
 - Exec into frontend pod, reach backend through service DNS name
-- Create frontend service with type NodePort
-- Access it from the nodes IP address
+- Create a frontend service with type NodePort
+- Access it from the node's IP address
 
 :bulb: If you get stuck somewhere along the way, you can check the solution in the done folder.
 
-### Step by step instructions
+### Step-by-step instructions
 
 <details>
 <summary>
@@ -225,7 +225,7 @@ Hint: the apply command can take more than one `-f` parameter to apply more than
 
 </details>
 
-- Check that the pods are running with `kubectl get pods` command.
+- Check that the pods are running with the `kubectl get pods` command.
 
 You should see something like this:
 
@@ -240,16 +240,16 @@ cluster network, so we will create a service of type `ClusterIP`.
 
 - Open the `backend-svc.yaml` file and fill in the missing parts.
 - apiVersion and kind are already filled in for you.
-- Metadata section should have the name `backend` and a label with key `run` and value `backend`.
-- Spec section should have a port with port `5000`, protocol `TCP` and targetPort `5000`.
-- Selector section should have a label with key `run` and value `backend`.
+- The metadata section should have the name `backend` and a label with key `run` and value `backend`.
+- The spec section should have a port with port `5000`, protocol `TCP` and targetPort `5000`.
+- The selector section should have a label with key `run` and value `backend`.
 - Type should be `ClusterIP`.
 
 > :bulb: If you get stuck somewhere along the way, you can check the solution in the done folder.
 
 - Apply backend-svc.yaml that you just created. `kubectl apply -f backend-svc.yaml`
 
-- Check that the service is created with `kubectl get services` command.
+- Check that the service is created with the `kubectl get services` command.
 
 You should see something like this:
 
@@ -269,7 +269,7 @@ root@frontend:/app#
 
 Make sure that you are inside a pod and not in your terminal window.
 
-- Try to reach backend pod through backend service `Cluster-IP` from within your frontend pod
+- Try to reach the backend pod through the backend service `Cluster-IP` from within your frontend pod
 
 ```shell
 curl 172.20.114.230:5000
@@ -291,10 +291,10 @@ You should see the same output as above.
 
 You can type `exit` or press `Ctrl-d` to exit from your container.
 
-- Next we create the service file for the frontend with type `NodePort`.
+- Next, we create the service file for the frontend with type `NodePort`.
 
 - While we can write manifests by hand, we can also use some tricks to generate boilerplate
-  manifests: For example we can use the `kubectl expose` command to create a service from a pod or deployment.
+  manifests: For example, we can use the `kubectl expose` command to create a service from a pod or deployment.
 
 > For example, `kubectl expose pod frontend --type=NodePort --port=5000` will create a service for
 > the frontend pod with type NodePort and port 5000.
@@ -311,7 +311,7 @@ You can type `exit` or press `Ctrl-d` to exit from your container.
 
 - Apply frontend-svc.yaml that you just created.
 
-- Check that the service is created with `kubectl get services` command.
+- Check that the service is created with the `kubectl get services` command.
 
 You should see something like this:
 
@@ -321,9 +321,9 @@ frontend          NodePort    10.106.136.250   <none>        5000:31941/TCP   23
 service/backend   ClusterIP   172.20.114.230   <none>        5000/TCP         23s
 ```
 
-- Note down the port number for the frontend service. In this case it is `31941` (yours will be different).
+- Note down the port number for the frontend service. In this case, it is `31941` (yours will be different).
 
-- Get the nodes IP address. Run `kubectl get nodes -o wide`.
+- Get the node's external IP address. Run `kubectl get nodes -o wide`.
 
 You should see something like this:
 
@@ -339,11 +339,11 @@ ip-10-0-62-15.eu-west-1.compute.internal    Ready    <none>   152m   v1.23.9-eks
 5.4.219-126.411.amzn2.x86_64   docker://20.10.17
 ```
 
-Copy the external IP address of any one of the nodes, for example, `34.244.123.152` and paste it in
+Copy the external IP address of any one of the nodes, for example, `34.244.123.152`, and paste it in
 your browser.
 
-Copy the port from your frontend service that looks something like `31941` and paste it after to
-your IP in the browser, separated by a colon (`:`), for example `34.244.123.152:31941` and load the
+Copy the port from your frontend service that looks something like `31941` and paste it after
+your IP in the browser, separated by a colon (`:`), for example `34.244.123.152:31941`, and load the
 page.
 
 Alternatively, you could also test it using curl from your terminal window.
@@ -366,7 +366,7 @@ You should see something like this:
 :bulb: Food for thought
 </summary>
 
-Think about why you didn't need to exec into a pod to test frontend service but needed it to test
+Think about why you didn't need to exec into a pod to test the frontend service, but needed it to test
 the backend service.
 
 </details>
@@ -380,7 +380,7 @@ Delete the pods and services with `kubectl delete pod frontend backend` and
 
 You have successfully tested connectivity between frontend and backend pods using services.
 
-### Extra: Filter on the basis of labels
+### Extra: Filter based on labels
 
 <details>
 <summary>
@@ -401,16 +401,16 @@ with the value bar, you would run the following command:
 
 `kubectl get pods --selector=foo!=bar`
 
-Try to apply the manifests again and write four commands that does the following:
+Try to apply the manifests again and write four commands that do the following:
 
 - List only the pods with the label app=frontend
 - List only the pods with the label app=backend
-- List only the pods where label app is not frontend
-- List only the pods where label app is not backend
+- List only the pods where the label app is not frontend
+- List only the pods where the label app is not backend
 
 The documentation on this can be found here:
 <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/>
 
-Remember to clean up after you are done.
+> **Note** Remember to clean up after you are done
 
 </details>

--- a/services.md
+++ b/services.md
@@ -186,7 +186,7 @@ service from the internet.
 
 There are other types of services, like `LoadBalancer`, but we won't cover them in this exercise.
 
-If you want to know more about Services, you can read more about them [here](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
+If you want to know more about Services, you can read more about them [publishing-services-service-types](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
 
 > :bulb: Hint: You can use the `kubectl explain` command to get more information about the fields
 > in the yaml file. For example, `kubectl explain service.spec` will give you more information

--- a/services.md
+++ b/services.md
@@ -13,7 +13,7 @@ between them.
 
 ## Service Discovery & Services
 
-One of the features of Kubernetes is that we do not have to care which machine our pods are
+One of the features of Kubernetes is that we do not have to know which machine our pods are
 running on. This does create an interesting problem for us - if we don't know where (the IP address)
 the pod is, how can we route traffic to it? This is solved by what is called **service discovery**,
 as the words imply, Kubernetes will look for your pods and dynamically route traffic to them.
@@ -32,9 +32,9 @@ the rest!
 The `service` then routes traffic to the pods that it selects. You can think of `service` as a kind of
 proxy - you route traffic to the service, and the service routes the traffic to your pods.
 
-While the `service` gets a static IP address, we prefer not to use it, because Kubernetes
-runs its own DNS server in the cluster network, and every time we create a `service`, a DNS record is
-created that points to the `service` IP address.
+While the `service` gets a static IP address, we prefer not to use it. Kubernetes
+runs its own DNS server in the cluster network, and every time we create a `service`,
+a DNS record that points to the `service` IP address is automatically created.
 The DNS record is always the `name` of the service, and can be referenced either from the same
 namespace by using the name or from a different namespace by using the long form:
 `<name>.<namespace>.svc.cluster.local`.
@@ -161,7 +161,7 @@ internet, but we can still access it from within the cluster using its `CLUSTER-
 - No matter what type of service you choose while _exposing_ your pod, Cluster-IP is always
   assigned to that particular service.
 
-- Every service has endpoints, which point to the actual pod serving as the backend of a particular
+- Every service has end-points, which point to the actual pod serving as the backend of a particular
   service.
 
 - As soon as a service is created and is assigned a Cluster-IP, an entry is made in Kubernetes'
@@ -186,7 +186,8 @@ service from the internet.
 
 There are other types of services, like `LoadBalancer`, but we won't cover them in this exercise.
 
-If you want to know more about Services, you can read more about them [Service types](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
+If you want to know more about Services, you can read more about them in the Kubernetes docs for
+[Service types](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
 
 > :bulb: Hint: You can use the `kubectl explain` command to get more information about the fields
 > in the YAML file. For example, `kubectl explain service.spec` will give you more information


### PR DESCRIPTION
This pull request updates multiple Kubernetes documentation files to improve clarity, grammar, and consistency. The changes focus on making instructions easier to follow, correcting typos, and standardizing terminology across the guides.

**Documentation improvements:**

* Reworded sentences for clarity and corrected grammar throughout `accessing-your-application.md`, including improved explanations of port-forwarding, step-by-step instructions, and environment variable usage. [[1]](diffhunk://#diff-919f2785193eee61b3d6e60156a2e4f405bdb12247e384a92f857d17da1dda6eL13-R19) [[2]](diffhunk://#diff-919f2785193eee61b3d6e60156a2e4f405bdb12247e384a92f857d17da1dda6eL35-R42) [[3]](diffhunk://#diff-919f2785193eee61b3d6e60156a2e4f405bdb12247e384a92f857d17da1dda6eL61-R61) [[4]](diffhunk://#diff-919f2785193eee61b3d6e60156a2e4f405bdb12247e384a92f857d17da1dda6eL81-R81) [[5]](diffhunk://#diff-919f2785193eee61b3d6e60156a2e4f405bdb12247e384a92f857d17da1dda6eL92-R115) [[6]](diffhunk://#diff-919f2785193eee61b3d6e60156a2e4f405bdb12247e384a92f857d17da1dda6eL126-R126) [[7]](diffhunk://#diff-919f2785193eee61b3d6e60156a2e4f405bdb12247e384a92f857d17da1dda6eL181-R183) [[8]](diffhunk://#diff-919f2785193eee61b3d6e60156a2e4f405bdb12247e384a92f857d17da1dda6eL193-R195) [[9]](diffhunk://#diff-919f2785193eee61b3d6e60156a2e4f405bdb12247e384a92f857d17da1dda6eL208-R211) [[10]](diffhunk://#diff-919f2785193eee61b3d6e60156a2e4f405bdb12247e384a92f857d17da1dda6eL221-R224) [[11]](diffhunk://#diff-919f2785193eee61b3d6e60156a2e4f405bdb12247e384a92f857d17da1dda6eL233-R235)
* Enhanced explanations and corrected terminology in `configmaps-secrets.md`, including clear distinctions between configmaps and secrets, better step-by-step instructions, and more precise descriptions of YAML manifests and environment variable injection. [[1]](diffhunk://#diff-2ff5488a74810808e78158faa887a1ac1fa58d0b4cfcd8e4fdaf8f0a5c19fa3bL11-R17) [[2]](diffhunk://#diff-2ff5488a74810808e78158faa887a1ac1fa58d0b4cfcd8e4fdaf8f0a5c19fa3bL26-R29) [[3]](diffhunk://#diff-2ff5488a74810808e78158faa887a1ac1fa58d0b4cfcd8e4fdaf8f0a5c19fa3bL104-R104) [[4]](diffhunk://#diff-2ff5488a74810808e78158faa887a1ac1fa58d0b4cfcd8e4fdaf8f0a5c19fa3bL116-R128) [[5]](diffhunk://#diff-2ff5488a74810808e78158faa887a1ac1fa58d0b4cfcd8e4fdaf8f0a5c19fa3bL154-R157) [[6]](diffhunk://#diff-2ff5488a74810808e78158faa887a1ac1fa58d0b4cfcd8e4fdaf8f0a5c19fa3bL171-R171) [[7]](diffhunk://#diff-2ff5488a74810808e78158faa887a1ac1fa58d0b4cfcd8e4fdaf8f0a5c19fa3bL197-R200) [[8]](diffhunk://#diff-2ff5488a74810808e78158faa887a1ac1fa58d0b4cfcd8e4fdaf8f0a5c19fa3bL241-R241) [[9]](diffhunk://#diff-2ff5488a74810808e78158faa887a1ac1fa58d0b4cfcd8e4fdaf8f0a5c19fa3bL269-R276) [[10]](diffhunk://#diff-2ff5488a74810808e78158faa887a1ac1fa58d0b4cfcd8e4fdaf8f0a5c19fa3bL343-R348) [[11]](diffhunk://#diff-2ff5488a74810808e78158faa887a1ac1fa58d0b4cfcd8e4fdaf8f0a5c19fa3bL374-R375)

**Terminology and consistency fixes:**

* Standardized technical terms and corrected spelling errors in `cheatsheet.md`, such as "Documentation" and "resource types and abbreviations."
* Improved terminology in `deployments-ingress.md`, such as clarifying "load balancing" and using "higher-level abstraction." [[1]](diffhunk://#diff-c15040aa2448b927dec5fae9cc933c7d6a6cad690817279a7837a7a30f576ef8L8-R8) [[2]](diffhunk://#diff-c15040aa2448b927dec5fae9cc933c7d6a6cad690817279a7837a7a30f576ef8L17-R17)